### PR TITLE
Fix hook order in crowdfunding page

### DIFF
--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -214,6 +214,13 @@ const CrowdfundingPage = () => {
     }
   }, []);
 
+  // --- Embedded Checkout State (Square Web Payments SDK) ---
+  const paymentsRef = useRef(null);
+  const cardRef = useRef(null);
+  const [cardLoaded, setCardLoaded] = useState(false);
+  const [cardInitAttempts, setCardInitAttempts] = useState(0);
+  const [squareConfigError, setSquareConfigError] = useState('');
+
   if (loading) {
     return <div className="text-center p-12">Loading campaign...</div>;
   }
@@ -248,13 +255,6 @@ const CrowdfundingPage = () => {
   // Specifically safeguard array types to prevent the .length error
   const story = campaignData.story || [];
   const faq = campaignData.faq || [];
-
-  // --- Embedded Checkout State (Square Web Payments SDK) ---
-  const paymentsRef = useRef(null);
-  const cardRef = useRef(null);
-  const [cardLoaded, setCardLoaded] = useState(false);
-  const [cardInitAttempts, setCardInitAttempts] = useState(0);
-  const [squareConfigError, setSquareConfigError] = useState('');
 
   // Dynamically load the Square Web Payments SDK script (only once)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep Square payment hooks mounted on every render by defining them before early returns in CrowdfundingPage
- ensure loading and error states still bail out after hook initialization to avoid React hook invariant violations

## Testing
- npx eslint src/pages/CrowdfundingPage.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d5a75b2cf08321ab019dc5bdabd19a