### PR TITLE
Refresh heading styles across pages

### DIFF
--- a/src/components/auth/RequireAuth.jsx
+++ b/src/components/auth/RequireAuth.jsx
@@ -23,7 +23,7 @@ export function RequireAuth({ children }) {
   if (!auth || !user) {
     return (
       <div className="mx-auto max-w-xl p-6 text-center">
-        <h2 className="text-xl font-semibold mb-2">Sign in required</h2>
+        <h2 className="heading-lg mb-2">Sign in required</h2>
         <p className="mb-4 text-gray-600">Please sign in to access this area.</p>
         <Link className="inline-block px-4 py-2 rounded bg-black text-white" to="/auth">Go to Sign In</Link>
       </div>

--- a/src/components/auth/RequirePartnerAccess.jsx
+++ b/src/components/auth/RequirePartnerAccess.jsx
@@ -39,7 +39,7 @@ export function RequirePartnerAccess({ toolKey, children }) {
   if (!user) {
     return (
       <div className="mx-auto max-w-xl p-6 text-center">
-        <h2 className="text-xl font-semibold mb-2">Sign in required</h2>
+        <h2 className="heading-lg mb-2">Sign in required</h2>
         <p className="mb-4 text-gray-600">Please sign in to access partner tools.</p>
         <Link className="inline-block px-4 py-2 rounded bg-black text-white" to="/auth">Go to Sign In</Link>
       </div>
@@ -48,7 +48,7 @@ export function RequirePartnerAccess({ toolKey, children }) {
   if (!allowed) {
     return (
       <div className="mx-auto max-w-xl p-6 text-center">
-        <h2 className="text-xl font-semibold mb-2">Access denied</h2>
+        <h2 className="heading-lg mb-2">Access denied</h2>
         <p className="mb-4 text-gray-600">Your account is not assigned to this tool.</p>
         <Link className="inline-block px-4 py-2 rounded border" to="/partner-portal">Back to Portal</Link>
       </div>

--- a/src/components/pricing/CostEstimator.jsx
+++ b/src/components/pricing/CostEstimator.jsx
@@ -161,7 +161,7 @@ export const CostEstimator = () => {
   if (showResults) {
     return (
       <div className="border border-gray-900 p-8 text-center">
-        <h3 className="text-2xl font-bold">All-Inclusive Ballpark Estimate</h3>
+        <h3 className="heading-lg heading-balance">All-inclusive ballpark estimate</h3>
         <p className="text-6xl font-bold my-4">${finalCost.toFixed(2)}</p>
         <div className="bg-gray-200 p-4 text-left mb-6 font-mono text-sm">
           {[`- Based on your selections for a ${userAnswers.serviceType} service.`].map(
@@ -180,7 +180,7 @@ export const CostEstimator = () => {
   const currentQData = questions[currentQuestionKey];
   return (
     <div className="relative w-full border border-gray-900 p-8 min-h-[400px]">
-      <h2 className="text-3xl font-bold mb-6">{currentQData.title}</h2>
+      <h2 className="heading-lg heading-balance mb-6">{currentQData.title}</h2>
       {currentQData.type === 'options' && (
         <div className="space-y-3 font-mono">
           {currentQData.options.map((opt) => (

--- a/src/components/ui/SectionHeader.jsx
+++ b/src/components/ui/SectionHeader.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 export default function SectionHeader({ overline, title, className = '' }) {
   return (
-    <div className={["space-y-1", className].filter(Boolean).join(' ')}>
+    <div className={["space-y-2", className].filter(Boolean).join(' ')}>
       {overline ? (
-        <div className="text-xs font-semibold uppercase tracking-wider text-neutral-500">{overline}</div>
+        <span className="heading-overline">{overline}</span>
       ) : null}
       {title ? (
-        <h2 className="text-heading">{title}</h2>
+        <h2 className="heading-xl heading-balance">{title}</h2>
       ) : null}
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -44,20 +44,128 @@ h4,
 h5,
 h6 {
   font-family: var(--font-display);
-  font-weight: 600;
-  line-height: 1.2;
+  font-weight: 650;
+  line-height: 1.08;
   margin-bottom: 0.5em;
+  color: #0f172a;
+  text-wrap: balance;
+  letter-spacing: -0.01em;
+}
+
+h1 {
+  font-size: clamp(2.65rem, 6vw, 4.5rem);
+  letter-spacing: -0.04em;
+  line-height: 1.05;
+}
+
+h2 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: -0.025em;
+}
+
+.heading-display {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.85rem, 6vw, 4.85rem);
+  line-height: 1.04;
+  letter-spacing: -0.045em;
+  color: #0b1220;
+  text-wrap: balance;
+}
+
+.heading-xl {
+  font-family: var(--font-display);
+  font-weight: 680;
+  font-size: clamp(2.1rem, 4.5vw, 3.25rem);
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+  color: #111827;
+  text-wrap: balance;
+}
+
+.heading-lg {
+  font-family: var(--font-display);
+  font-weight: 650;
+  font-size: clamp(1.65rem, 3vw, 2.5rem);
+  line-height: 1.12;
+  letter-spacing: -0.02em;
+  color: #111827;
+  text-wrap: balance;
+}
+
+.heading-subtitle {
+  font-family: var(--font-display);
+  font-weight: 520;
+  font-size: clamp(1.2rem, 2.5vw, 1.75rem);
+  line-height: 1.45;
+  letter-spacing: -0.01em;
+  color: #475569;
+  text-wrap: pretty;
+}
+
+.heading-overline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.38em;
+  color: #f97316;
+}
+
+.heading-overline::before {
+  content: '';
+  display: inline-block;
+  width: 3rem;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.45;
+}
+
+.heading-accent {
+  background: linear-gradient(110deg, #f97316 0%, #ef4444 45%, #8b5cf6 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.heading-balance {
+  text-wrap: balance;
+}
+
+.heading-underline {
+  position: relative;
+  display: inline-block;
+  padding-bottom: 0.5rem;
+}
+
+.heading-underline::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 3.5rem;
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #f97316 0%, rgba(249, 115, 22, 0));
 }
 
 .text-hero {
   font-size: clamp(3rem, 6vw, 4.5rem);
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.03em;
   line-height: 1.05;
 }
 
 .text-heading {
   font-size: clamp(1.75rem, 3vw, 2.5rem);
+  font-family: var(--font-display);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
 }
 
 .text-body {

--- a/src/pages/AboutUsPage.jsx
+++ b/src/pages/AboutUsPage.jsx
@@ -68,7 +68,7 @@ const AboutUsPage = () => {
           <header className="relative overflow-hidden rounded-2xl ring-1 ring-neutral-200 bg-gradient-to-br from-neutral-50 to-white">
             <div className="grid gap-10 md:grid-cols-2 md:items-center p-8 md:p-12 lg:p-16">
               <div>
-                <h1 id="about-hero-title" className="text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight">Local Effort</h1>
+                <h1 id="about-hero-title" className="heading-display heading-balance">Local Effort</h1>
                 <p className="mt-4 text-lg text-neutral-700 max-w-xl">
                   Obsessively local since 2022 — because it’s healthier, tastier, and better for Minnesota.
                 </p>

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -58,7 +58,7 @@ export default function AuthPage() {
 
   return (
     <div className="mx-auto max-w-md p-6 text-center">
-      <h1 className="text-2xl font-semibold mb-4">Sign in</h1>
+      <h1 className="heading-lg mb-4">Sign in</h1>
       {error && (
         <div className="mb-4 p-3 rounded bg-red-50 text-red-700 text-sm text-left">
           {error}

--- a/src/pages/BlogList.jsx
+++ b/src/pages/BlogList.jsx
@@ -25,7 +25,7 @@ const BlogList = () => {
       <Helmet>
         <title>Blog | Local Effort</title>
       </Helmet>
-      <h1 className="text-4xl font-bold mb-6">Blog</h1>
+      <h1 className="heading-xl heading-balance mb-6">Blog</h1>
       {error && <div className="text-red-700 bg-red-50 border border-red-200 p-3 rounded mb-4">{error}</div>}
       <ul className="space-y-4">
         {posts.map((p) => (

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -32,7 +32,7 @@ const BlogPost = () => {
         <title>{post?.title ? `${post.title} | Blog` : 'Blog'} | Local Effort</title>
       </Helmet>
       <Link to="/blog" className="text-sm underline">← Back to blog</Link>
-      <h1 className="text-4xl font-bold mt-2">{post.title}</h1>
+      <h1 className="heading-xl heading-balance mt-4">{post.title}</h1>
       <div className="text-sm text-gray-500 mt-1">{post.publishedAt ? new Date(post.publishedAt).toLocaleDateString() : ''}</div>
       <article className="prose max-w-none mt-6">
         <PortableText value={post.body} />

--- a/src/pages/CampaignsPage.jsx
+++ b/src/pages/CampaignsPage.jsx
@@ -21,7 +21,7 @@ export default function CampaignsPage() {
 
   return (
     <div className="mx-auto max-w-5xl p-4">
-      <h1 className="text-2xl font-semibold mb-4">Campaigns</h1>
+      <h1 className="heading-lg mb-4">Campaigns</h1>
       <div className="space-y-3">
         <input className="border p-2 w-full" value={name} onChange={(e) => setName(e.target.value)} />
         <textarea className="border p-2 w-full h-64" value={html} onChange={(e) => setHtml(e.target.value)} />

--- a/src/pages/CookbookRecipePage.jsx
+++ b/src/pages/CookbookRecipePage.jsx
@@ -293,7 +293,7 @@ export default function CookbookRecipePage() {
         <header className="mt-6 space-y-5">
           <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
             <div className="space-y-2">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900">{recipeTitle}</h1>
+              <h1 className="heading-xl heading-balance">{recipeTitle}</h1>
               {cookbookTitle ? (
                 <p className="text-lg font-medium text-gray-700">{cookbookTitle}</p>
               ) : null}
@@ -358,7 +358,7 @@ export default function CookbookRecipePage() {
 
         <main className="mt-10 grid gap-8 lg:grid-cols-[2fr,1fr]">
           <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-xl font-semibold text-gray-900">Recipe</h2>
+            <h2 className="heading-lg">Recipe</h2>
             {ingredientsPresent ? (
               <div className="mt-4">
                 <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Ingredients</h3>
@@ -388,7 +388,7 @@ export default function CookbookRecipePage() {
 
           <aside className="space-y-6">
             <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900">Metadata</h2>
+              <h2 className="heading-subtitle text-neutral-700">Metadata</h2>
               <dl className="mt-4 space-y-3 text-sm text-gray-700">
                 {creators.length ? (
                   <div>
@@ -431,7 +431,7 @@ export default function CookbookRecipePage() {
 
             {iiifManifest ? (
               <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-                <h2 className="text-lg font-semibold text-gray-900">Page viewer</h2>
+                <h2 className="heading-subtitle text-neutral-700">Page viewer</h2>
                 <iframe
                   title="IIIF Viewer"
                   src={`https://uv-v4.netlify.app/#?manifest=${encodeURIComponent(iiifManifest)}`}

--- a/src/pages/CookbookSearchPage.jsx
+++ b/src/pages/CookbookSearchPage.jsx
@@ -369,8 +369,8 @@ export default function CookbookSearchPage() {
     <div className="container mx-auto max-w-5xl px-4 py-12">
       <header className="space-y-4 pb-10">
         <div className="space-y-2">
-          <p className="text-sm font-semibold uppercase tracking-wide text-blue-600">Cookbook Archive</p>
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900">Find recipes from community cookbooks</h1>
+          <p className="heading-overline text-blue-600">Cookbook archive</p>
+          <h1 className="heading-xl heading-balance">Find recipes from community cookbooks</h1>
           <p className="text-base text-gray-600">{heroSubtitle}</p>
         </div>
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
@@ -561,7 +561,7 @@ export default function CookbookSearchPage() {
 
       <section className="mt-12 rounded-2xl border border-gray-200 bg-gradient-to-br from-blue-50 via-white to-purple-50 p-8 shadow-sm">
         <div className="space-y-3">
-          <h2 className="text-2xl font-semibold text-gray-900">Help us expand the archive</h2>
+          <h2 className="heading-lg heading-balance">Help us expand the archive</h2>
           <p className="text-base text-gray-600">
             We are indexing community cookbooks from Minnesota, Wisconsin, and neighboring states. Have a scan or lead we should include?
           </p>

--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -404,11 +404,11 @@ const CrowdfundingPage = () => {
   <div className="space-y-16 mx-auto max-w-6xl px-4 md:px-6 lg:px-8">
         {/* --- Page Header --- */}
         <div>
-                <h1 className="text-4xl md:text-6xl font-bold uppercase tracking-[-0.02em] leading-[1.02]">{title}</h1>
+                <h1 className="heading-display heading-balance">{title}</h1>
                 {/* Short description rendered with Portable Text (supports paragraphs and formatting) */}
                 <div className="mt-6 md:mt-8 text-body max-w-2xl">
                   {taglineBlock && (
-                    <h2 className="text-2xl md:text-3xl font-semibold leading-snug tracking-tight">
+                    <h2 className="heading-lg text-neutral-600">
                       {blockText(taglineBlock)}
                     </h2>
                   )}

--- a/src/pages/EventsPage.jsx
+++ b/src/pages/EventsPage.jsx
@@ -12,7 +12,7 @@ const EventsPage = () => (
       />
     </Helmet>
     <div className="space-y-16">
-      <h2 className="text-5xl md:text-7xl font-bold uppercase">Dinners & Events</h2>
+      <h1 className="heading-display heading-balance">Dinners & events</h1>
       <p className="font-mono text-lg max-w-3xl">
         We bring our passion for food and hospitality to your home or venue. We specialize in
         cooking for parties from 2 to 50 people.

--- a/src/pages/GalleryPage.jsx
+++ b/src/pages/GalleryPage.jsx
@@ -253,7 +253,7 @@ const GalleryPage = () => {
           ))}
       </Helmet>
       <div className="container mx-auto px-4 py-8">
-        <h1 className="text-4xl font-bold mb-4 text-center">pictures of food.</h1>
+        <h1 className="heading-xl heading-balance text-center">Pictures of food.</h1>
 
         <input
           type="text"

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -469,18 +469,18 @@ const HomePage = () => {
               variants={fadeInLeft}
               initial="initial"
               animate="animate"
-              className="text-4xl md:text-6xl font-bold tracking-[-0.02em] leading-[1.02]"
+              className="heading-display"
             >
-              Minnesotan Food for your Functions.
+              Minnesotan food <span className="heading-accent">for your functions.</span>
             </motion.h1>
             <motion.h2
               variants={fadeInLeft}
               initial="initial"
               animate="animate"
               transition={{ delay: 0.05 }}
-              className="text-3xl md:text-5xl font-bold text-neutral-600 tracking-[-0.02em] leading-[1.0] -mt-2 md:-mt-4"
+              className="heading-subtitle text-neutral-600"
             >
-              Personal Chef in Minneapolis–St. Paul
+              Personal chef services in Minneapolis–St. Paul
             </motion.h2>
             <motion.p
               variants={fadeInUp}

--- a/src/pages/InboxPage.jsx
+++ b/src/pages/InboxPage.jsx
@@ -32,7 +32,7 @@ export default function InboxPage() {
 
   return (
     <div className="mx-auto max-w-5xl p-4">
-      <h1 className="text-2xl font-semibold mb-4">Inbox</h1>
+      <h1 className="heading-lg mb-4">Inbox</h1>
       {loading && <p>Loading…</p>}
       {error && (
         <div className="p-4 border border-red-200 bg-red-50 rounded mb-4">

--- a/src/pages/MealPrepPage.jsx
+++ b/src/pages/MealPrepPage.jsx
@@ -145,9 +145,9 @@ export const MealPrepPage = () => {
       </Helmet>
       <div className="space-y-16 mx-auto max-w-6xl px-4 md:px-6 lg:px-8">
         <header className="flex items-center justify-between">
-          <h2 className="text-4xl md:text-6xl font-bold uppercase tracking-[-0.02em] leading-[1.02]">
-            Weekly Meal Prep
-          </h2>
+          <h1 className="heading-display heading-balance">
+            Weekly meal prep
+          </h1>
           <div className="flex items-center gap-3">{/* Public access — no sign-in required */}</div>
         </header>
 

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -65,7 +65,7 @@ export default function MenuPage() {
         <link rel="canonical" href="https://localeffortfood.com/menu" />
         <script type="application/ld+json">{JSON.stringify(menuJsonLd)}</script>
       </Helmet>
-      <h1 className="text-4xl font-bold mb-4 text-center">Past Menu Examples.</h1>
+      <h1 className="heading-xl heading-balance text-center">Past menu examples.</h1>
       <div className="prose-lite max-w-3xl mx-auto text-center mb-8">
         <p>
           these are all real menus from events in the past couple years, just to show how wide the options are. We love to &quot;make it local.&quot;

--- a/src/pages/PartnerPortalPage.jsx
+++ b/src/pages/PartnerPortalPage.jsx
@@ -13,7 +13,7 @@ const PartnerPortalPage = () => {
         <meta name="description" content="Tools and resources for Local Effort partners." />
       </Helmet>
       <div className="space-y-6">
-        <h2 className="text-5xl md:text-7xl font-bold uppercase">Partner Portal</h2>
+        <h1 className="heading-display heading-balance">Partner portal</h1>
         <p className="text-body max-w-2xl">Public tools and links for partners. No sign-in required.</p>
 
         <ToolGrid />

--- a/src/pages/PartnerPortalWelcome.jsx
+++ b/src/pages/PartnerPortalWelcome.jsx
@@ -16,7 +16,7 @@ export default function PartnerPortalWelcome() {
         <meta name="description" content="Local Effort partner tools and resources." />
       </Helmet>
       <div className="space-y-6">
-        <h2 className="text-5xl md:text-7xl font-bold uppercase">Partner Portal</h2>
+        <h1 className="heading-display heading-balance">Partner portal</h1>
         <p className="text-body max-w-2xl">Welcome! Access tools and resources for partners. Sign in to see your tools.</p>
 
         <div className="p-6 border rounded-md max-w-xl bg-neutral-50">

--- a/src/pages/PizzaPartyPage.jsx
+++ b/src/pages/PizzaPartyPage.jsx
@@ -285,7 +285,7 @@ const PizzaPartyPage = () => {
       <div className="mx-auto max-w-6xl px-4 py-10 space-y-14">
         {/* Intro */}
         <div className="text-center space-y-4">
-          <h1 className="font-display text-4xl md:text-5xl font-bold tracking-tight">Pizza Party Special</h1>
+          <h1 className="heading-display heading-balance">Pizza party special</h1>
           <p className="mt-2 text-xl md:text-2xl text-neutral-800 max-w-3xl mx-auto leading-relaxed">Host an unforgettable pizza experience right in your home. We bring the oven, the dough, and the vibes. We call it <strong>Local Pizza</strong>.</p>
         </div>
 
@@ -295,7 +295,7 @@ const PizzaPartyPage = () => {
             <div className="absolute inset-0 pointer-events-none opacity-[0.15]" style={{backgroundImage:'radial-gradient(circle at 30% 30%, #fb923c, transparent 60%)'}} />
             <div className="relative grid md:grid-cols-3 gap-8 items-center">
               <div className="md:col-span-2 space-y-4">
-                <h2 className="text-2xl md:text-3xl font-bold">Pizza Party in Your Home</h2>
+                <h2 className="heading-lg heading-balance">Pizza party in your home</h2>
                 <ul className="list-disc list-inside text-neutral-700 text-sm md:text-base space-y-1">
                   <li>Up to 15 guests</li>
                   <li>100% local midwest ingredients, slow-fermented sourdough crust</li>

--- a/src/pages/PricingPage.jsx
+++ b/src/pages/PricingPage.jsx
@@ -50,10 +50,14 @@ const PricingPage = () => {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
-          className="text-center"
+          className="text-center space-y-4"
         >
-          <h2 className="text-4xl font-extrabold uppercase mb-4">Pricing</h2>
-          <h3 className="text-2xl font-semibold mb-2">It’s not as expensive as you think.</h3>
+          <h1 className="heading-display heading-balance">
+            Personal chef pricing, simplified.
+          </h1>
+          <p className="heading-subtitle text-neutral-600 max-w-3xl mx-auto">
+            It’s not as expensive as you think.
+          </p>
           <p className="text-lg text-gray-700 max-w-3xl mx-auto">
             We tailor pricing closely to your needs. We try to stay competitive to an evening at a nice restaurant, (or to the price of takeout, depending on the request). Oftentimes, we're the much better deal.
           </p>
@@ -71,7 +75,7 @@ const PricingPage = () => {
           viewport={{ once: true, amount: 0.2 }}
           transition={{ duration: 0.5 }}
         >
-          <h3 className="text-2xl font-bold uppercase mb-4">Cost Estimator</h3>
+          <h2 className="heading-xl heading-underline">Cost estimator</h2>
           <CostEstimator />
         </motion.section>
 
@@ -83,7 +87,7 @@ const PricingPage = () => {
           transition={{ duration: 0.5 }}
           className="space-y-4"
         >
-          <h3 className="text-2xl font-bold uppercase">Personal Chef Pricing FAQ</h3>
+          <h2 className="heading-xl heading-underline">Personal chef pricing FAQ</h2>
           <p className="text-gray-700">
             Wondering how much a personal chef costs in Minneapolis? These quick answers summarize what most households and event planners invest for chef-prepared menus, staffing, and meal prep support.
           </p>

--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -60,7 +60,7 @@ export default function ProductPage() {
             )}
           </div>
           <div>
-            <h1 className="text-2xl font-bold">{product.title}</h1>
+            <h1 className="heading-lg">{product.title}</h1>
             {product.shortDescription && (
               <p className="mt-2 text-neutral-700">{product.shortDescription}</p>
             )}

--- a/src/pages/ReleasesPage.jsx
+++ b/src/pages/ReleasesPage.jsx
@@ -121,7 +121,7 @@ const ReleasesPage = () => {
                 </div>
                 <div className="grid gap-3 md:grid-cols-[2fr,1fr] md:items-start">
                   <div className="space-y-3">
-                    <h1 className="text-3xl md:text-4xl font-semibold text-neutral-900 leading-tight">
+                    <h1 className="heading-xl heading-balance">
                       Roseville-Based Local Effort Seeks Support to Craft 1,000 Fully Local Pizzas
                     </h1>
                     <p className="text-base text-neutral-700 leading-relaxed">
@@ -158,7 +158,7 @@ const ReleasesPage = () => {
               </div>
 
               <section aria-labelledby="campaign-highlights" className="space-y-3">
-                <h2 id="campaign-highlights" className="text-sm uppercase tracking-[0.3em] text-neutral-600">
+                <h2 id="campaign-highlights" className="heading-overline text-neutral-600">
                   Campaign Snapshot
                 </h2>
                 <ul className="space-y-3 text-neutral-800">
@@ -195,7 +195,7 @@ const ReleasesPage = () => {
 
           <section className="mt-16 space-y-8">
             <div className="space-y-3">
-              <h2 className="text-3xl font-semibold tracking-tight text-neutral-900">Press Kit</h2>
+              <h2 className="heading-xl heading-balance">Press kit</h2>
               <p className="text-neutral-600 max-w-3xl">
                 Download-ready facts, leadership bios, and campaign details to support coverage of Local Effort&apos;s 1,000 pizza crowdfunding initiative.
               </p>
@@ -311,7 +311,7 @@ const ReleasesPage = () => {
 
           {/* Archived previous release */}
           <section className="mt-24" aria-labelledby="archive-heading">
-            <h2 id="archive-heading" className="text-2xl font-semibold tracking-tight text-neutral-900 mb-6">Previous Release (Archived)</h2>
+            <h2 id="archive-heading" className="heading-lg heading-balance mb-6">Previous release (archived)</h2>
             <details className="group bg-white rounded-2xl border border-neutral-200 shadow-sm">
               <summary className="cursor-pointer list-none px-6 py-4 flex items-center justify-between">
                 <span className="font-medium text-neutral-800">Local Effort Launches Crowdfunding Campaign to Craft 1,000 Local Pizzas</span>

--- a/src/pages/SalePage.jsx
+++ b/src/pages/SalePage.jsx
@@ -76,7 +76,7 @@ const SalePage = () => {
 
       <div className="flex items-start justify-between mb-4 gap-4">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Sale</h1>
+          <h1 className="heading-xl heading-balance">Sale</h1>
           {saleIntro.subheading && (
             <p className="mt-1 text-neutral-700">{saleIntro.subheading}</p>
           )}

--- a/src/pages/WeeklyList.jsx
+++ b/src/pages/WeeklyList.jsx
@@ -25,7 +25,7 @@ const WeeklyList = () => {
       <Helmet>
         <title>Weekly Meal Prep Journal | Local Effort</title>
       </Helmet>
-      <h1 className="text-4xl font-bold mb-6">Weekly Meal Prep Journal</h1>
+      <h1 className="heading-xl heading-balance mb-6">Weekly meal prep journal</h1>
       {error && <div className="text-red-700 bg-red-50 border border-red-200 p-3 rounded mb-4">{error}</div>}
       <ul className="space-y-4">
         {posts.map((p) => (

--- a/src/pages/WeeklyPost.jsx
+++ b/src/pages/WeeklyPost.jsx
@@ -47,7 +47,7 @@ const WeeklyPost = () => {
         <title>{post?.title ? `${post.title} | Weekly Meal Prep Journal` : 'Weekly Meal Prep Journal'} | Local Effort</title>
       </Helmet>
       <Link to="/weekly" className="text-sm underline">← Back to Weekly Meal Prep Journal</Link>
-      <h1 className="text-4xl font-bold mt-2">{post.title}</h1>
+      <h1 className="heading-xl heading-balance mt-4">{post.title}</h1>
       <div className="text-sm text-gray-500 mt-1">{post.publishedAt ? new Date(post.publishedAt).toLocaleDateString() : ''}</div>
       {post.mainImage?.asset && (
         <div className="mt-4">

--- a/src/pages/_CityPage.jsx
+++ b/src/pages/_CityPage.jsx
@@ -68,8 +68,8 @@ const CityPage = ({ city, h1, description, canonical, images, faq }) => {
         {faqLd && <script type="application/ld+json">{JSON.stringify(faqLd)}</script>}
       </Helmet>
 
-      <h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-4">{h1}</h1>
-      <h2 className="text-xl text-neutral-700 mb-6">In-home private chef dinners • Weekly meal prep • Small event catering</h2>
+      <h1 className="heading-xl heading-balance mb-4">{h1}</h1>
+      <h2 className="heading-subtitle text-neutral-600 mb-6">In-home private chef dinners • Weekly meal prep • Small event catering</h2>
 
       <div className="prose prose-neutral max-w-none">
         <p>{metaDesc}</p>


### PR DESCRIPTION
## Summary
- introduce a shared heading scale in `index.css` with accent, overline, and underline helpers
- update `SectionHeader`, hero banners, and page titles to use the new styling on home, crowdfunding, pricing, and related pages
- refresh supporting components like the cost estimator and auth gates to match the new typography system

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6dfd0ec248321b3103f49848b4b4d