### PR TITLE
Improve crowdfunding checkout UI and Square integration

### DIFF
--- a/src/components/crowdfunding/PrioritiesPie.jsx
+++ b/src/components/crowdfunding/PrioritiesPie.jsx
@@ -1,0 +1,114 @@
+import React, { useMemo } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '../ui/card';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+// ----- Raw items (edit these numbers to change the budget) -----
+const items = {
+  fulfillment: [
+    { name: 'Cheese', amount: 900 },
+    { name: 'Flour', amount: 150 },
+    { name: 'Other ingredients', amount: 500 },
+  ],
+  debt: [
+    { name: 'Car', amount: 1800 },
+    { name: 'Will', amount: 1500 },
+    { name: 'Adam', amount: 1800 },
+  ],
+  equipment: [
+    { name: 'Two additional ovens', amount: 1000 * 2 },
+    { name: 'Assorted pizza tools', amount: 500 },
+  ],
+  marketing: [
+    { name: 'Ads', amount: 1000 },
+    { name: 'Packaging/Stickers', amount: 400 },
+    { name: 'Video/Sound', amount: 1200 },
+  ],
+};
+
+// Funding goal and unit price (kept for reference/consistency checks)
+const GOAL = 25_000;
+const PIZZA_PRICE = 15;
+const PIZZAS_NEEDED = Math.ceil(GOAL / PIZZA_PRICE); // 1,667
+
+const CATEGORY_LABEL = {
+  fulfillment: 'Ingredients (Fulfillment)',
+  debt: 'Debt & Operations',
+  equipment: 'Equipment Upgrades',
+  marketing: 'Marketing',
+};
+
+const COLORS = {
+  fulfillment: '#16a34a', // green
+  debt: '#ef4444', // red
+  equipment: '#6366f1', // indigo
+  marketing: '#f59e0b', // amber
+};
+
+const sum = (rows) => rows.reduce((total, row) => total + row.amount, 0);
+
+const totalsByCategory = () => ({
+  fulfillment: sum(items.fulfillment),
+  debt: sum(items.debt),
+  equipment: sum(items.equipment),
+  marketing: sum(items.marketing),
+});
+
+const tooltipFormatter = (value) => {
+  const numeric = Number(value) || 0;
+  return `$${numeric.toLocaleString()}`;
+};
+
+const PrioritiesPie = () => {
+  const totals = useMemo(() => totalsByCategory(), []);
+  const grandTotal = totals.fulfillment + totals.debt + totals.equipment + totals.marketing;
+
+  const pieData = useMemo(
+    () =>
+      Object.keys(totals).map((key) => ({
+        name: CATEGORY_LABEL[key],
+        value: totals[key],
+        key,
+      })),
+    [totals]
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.assert(totals.fulfillment === 1550, 'Fulfillment should total $1,550');
+    console.assert(totals.debt === 5100, 'Debt & Operations should total $5,100');
+    console.assert(totals.equipment === 2500, 'Equipment Upgrades should total $2,500');
+    console.assert(totals.marketing === 2600, 'Marketing should total $2,600');
+    console.assert(grandTotal === 11750, 'Grand total should be $11,750');
+    console.assert(PIZZAS_NEEDED === 1667, 'Pizzas needed should be 1,667 for a $25k goal at $15 each');
+    const sumSlices = pieData.reduce((acc, slice) => acc + slice.value, 0);
+    console.assert(sumSlices === grandTotal, 'Pie slices should sum to the grand total');
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Priorities and Allocations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-80 w-full">
+            <ResponsiveContainer>
+              <PieChart>
+                <Pie dataKey="value" data={pieData} nameKey="name" outerRadius={120} label>
+                  {pieData.map((entry) => (
+                    <Cell key={entry.key} fill={COLORS[entry.key]} />
+                  ))}
+                </Pie>
+                <Tooltip formatter={tooltipFormatter} />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default PrioritiesPie;
+
+export { GOAL, PIZZA_PRICE, PIZZAS_NEEDED };

--- a/src/hooks/useSquareCard.js
+++ b/src/hooks/useSquareCard.js
@@ -1,5 +1,127 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 
+const SQUARE_SCRIPT_ATTR = 'data-square-sdk';
+let squareScriptState = { url: null, promise: null };
+
+const readSquareRuntimeConfig = () => {
+  if (typeof window === 'undefined') {
+    return {
+      appId: null,
+      locationId: null,
+      sdkUrl: '',
+      isSandbox: false,
+      environment: 'production',
+    };
+  }
+
+  const runtimeAppId =
+    window.__SQUARE_APP_ID__ ||
+    (import.meta?.env?.VITE_SQUARE_APP_ID) ||
+    window.SQUARE_APPLICATION_ID ||
+    '';
+
+  const envHintRaw = (window.__SQUARE_ENV__ ?? import.meta?.env?.VITE_SQUARE_ENV ?? '')
+    .toString()
+    .trim()
+    .toLowerCase();
+
+  const hostname = window.location?.hostname || '';
+  let isSandbox = false;
+  if (['sandbox', 'dev', 'development', 'test'].includes(envHintRaw)) {
+    isSandbox = true;
+  } else if (['production', 'prod', 'live'].includes(envHintRaw)) {
+    isSandbox = false;
+  } else if (runtimeAppId.startsWith('sandbox-')) {
+    isSandbox = true;
+  } else if (/localhost$/i.test(hostname) || hostname === '127.0.0.1') {
+    isSandbox = true;
+  }
+
+  const sdkUrl = isSandbox
+    ? 'https://sandbox.web.squarecdn.com/v1/square.js'
+    : 'https://web.squarecdn.com/v1/square.js';
+
+  return {
+    appId: runtimeAppId || null,
+    locationId:
+      window.__SQUARE_LOCATION_ID__ ||
+      (import.meta?.env?.VITE_SQUARE_LOCATION_ID) ||
+      window.SQUARE_LOCATION_ID ||
+      null,
+    sdkUrl,
+    isSandbox,
+    environment: isSandbox ? 'sandbox' : 'production',
+  };
+};
+
+const ensureSquareSdkScript = (sdkUrl, isSandbox) => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return Promise.reject(new Error('Square SDK requires a browser environment.'));
+  }
+
+  if (squareScriptState.promise && squareScriptState.url === sdkUrl) {
+    return squareScriptState.promise;
+  }
+
+  let script = document.querySelector(`script[${SQUARE_SCRIPT_ATTR}]`);
+  if (script && (script.getAttribute('src') || '') !== sdkUrl) {
+    script.parentElement?.removeChild(script);
+    script = null;
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    let scriptEl = script;
+
+    const cleanup = () => {
+      if (!scriptEl) return;
+      scriptEl.removeEventListener('load', handleLoad);
+      scriptEl.removeEventListener('error', handleError);
+    };
+
+    const handleLoad = () => {
+      if (scriptEl) {
+        scriptEl.setAttribute('data-square-loaded', 'true');
+      }
+      cleanup();
+      resolve();
+    };
+
+    const handleError = (event) => {
+      cleanup();
+      const err = event instanceof Error ? event : new Error('Failed to load Square SDK');
+      reject(err);
+    };
+
+    if (scriptEl) {
+      scriptEl.dataset.squareSdkEnv = isSandbox ? 'sandbox' : 'production';
+      const alreadyLoaded = scriptEl.getAttribute('data-square-loaded') === 'true';
+      if (alreadyLoaded || window.Square) {
+        resolve();
+        return;
+      }
+      scriptEl.addEventListener('load', handleLoad, { once: true });
+      scriptEl.addEventListener('error', handleError, { once: true });
+    } else {
+      scriptEl = document.createElement('script');
+      scriptEl.src = sdkUrl;
+      scriptEl.async = true;
+      scriptEl.dataset.squareSdk = 'true';
+      scriptEl.dataset.squareSdkEnv = isSandbox ? 'sandbox' : 'production';
+      scriptEl.addEventListener('load', handleLoad, { once: true });
+      scriptEl.addEventListener('error', handleError, { once: true });
+      document.head.appendChild(scriptEl);
+    }
+  }).catch((err) => {
+    if (squareScriptState.url === sdkUrl) {
+      squareScriptState = { url: null, promise: null };
+    }
+    throw err;
+  });
+
+  squareScriptState = { url: sdkUrl, promise };
+  return promise;
+};
+
 /**
  * useSquareCard - shared hook to load Square Web Payments SDK, initialize card, and provide tokenize helper.
  * @param {string} containerId - DOM selector id (e.g. '#cf-card-container') to attach card to.
@@ -11,6 +133,7 @@ export function useSquareCard(containerId, enabled, deps = []) {
   const cardRef = useRef(null);
   const [cardLoaded, setCardLoaded] = useState(false);
   const [attempts, setAttempts] = useState(0);
+  const attemptsRef = useRef(0);
   const [error, setError] = useState('');
   const [loadingScript, setLoadingScript] = useState(false);
   const attachStartedRef = useRef(false);
@@ -33,66 +156,42 @@ export function useSquareCard(containerId, enabled, deps = []) {
       setCardLoaded(false);
       setError('');
       setAttempts(0);
+      attemptsRef.current = 0;
     } catch (_) { /* ignore */ }
   }, []);
 
   // Inject script (once)
   useEffect(() => {
     if (!enabled) return;
-    // Detect desired mode using explicit env first, then app-id heuristics, lastly localhost fallback.
-    const runtimeAppId = (window?.__SQUARE_APP_ID__) || (import.meta?.env?.VITE_SQUARE_APP_ID) || window?.SQUARE_APPLICATION_ID || '';
-    const envHint = (() => {
-      const raw = (window?.__SQUARE_ENV__ ?? import.meta?.env?.VITE_SQUARE_ENV ?? '').toString().trim().toLowerCase();
-      if (!raw) return '';
-      if (['sandbox', 'dev', 'development', 'test'].includes(raw)) return 'sandbox';
-      if (['production', 'prod', 'live'].includes(raw)) return 'production';
-      return raw;
-    })();
-    const hostname = typeof window !== 'undefined' ? window.location.hostname : '';
-    let isSandbox = false;
-    if (envHint === 'sandbox') {
-      isSandbox = true;
-    } else if (envHint === 'production') {
-      isSandbox = false;
-    } else if (runtimeAppId.startsWith('sandbox-')) {
-      isSandbox = true;
-    } else if (/localhost$/i.test(hostname) || hostname === '127.0.0.1') {
-      isSandbox = true;
-    }
-    const sdkUrl = isSandbox ? 'https://sandbox.web.squarecdn.com/v1/square.js' : 'https://web.squarecdn.com/v1/square.js';
-    const existing = document.querySelector('script[data-square-sdk]');
-    if (!existing) {
-      const sc = document.createElement('script');
-      sc.src = sdkUrl;
-      sc.async = true;
-      sc.dataset.squareSdk = 'true';
-      sc.dataset.squareSdkEnv = isSandbox ? 'sandbox' : 'production';
-      sc.onerror = () => {
-        setError('Failed to load payment script.');
-        setLoadingScript(false);
-      };
-      setLoadingScript(true);
-      sc.onload = () => setLoadingScript(false);
-      document.head.appendChild(sc);
-    } else {
-      // Validate that existing script matches desired environment
-      const currentUrl = existing.getAttribute('src') || '';
-      if (currentUrl !== sdkUrl) {
-        // Env mismatch: show warning but do not replace mid-flight.
-        setError(prev => prev || 'Payment script environment mismatch (refresh may be required).');
-        setEnvInfo(info => ({ ...info, mismatch: true }));
-      } else {
-        setEnvInfo(info => ({ ...info, mismatch: false }));
-      }
-    }
-    setEnvInfo(info => ({
+    let cancelled = false;
+    const config = readSquareRuntimeConfig();
+
+    setEnvInfo((info) => ({
       ...info,
-      appId: runtimeAppId || null,
-      locationId: (window?.__SQUARE_LOCATION_ID__) || (import.meta?.env?.VITE_SQUARE_LOCATION_ID) || window?.SQUARE_LOCATION_ID || null,
-      sdkUrl,
-      sandbox: isSandbox,
-      environment: isSandbox ? 'sandbox' : 'production',
+      appId: config.appId,
+      locationId: config.locationId,
+      sdkUrl: config.sdkUrl,
+      sandbox: config.isSandbox,
+      environment: config.environment,
+      mismatch: false,
     }));
+
+    setLoadingScript(true);
+    ensureSquareSdkScript(config.sdkUrl, config.isSandbox)
+      .then(() => {
+        if (cancelled) return;
+        setLoadingScript(false);
+        setError((prev) => (prev && prev.toLowerCase().includes('payment script') ? '' : prev));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setLoadingScript(false);
+        setError((prev) => prev || err?.message || 'Failed to load payment script.');
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [enabled]);
 
   // Initialize card
@@ -100,9 +199,9 @@ export function useSquareCard(containerId, enabled, deps = []) {
     if (!enabled) return;
     const abortController = new AbortController();
     const { signal } = abortController;
-    const appId = (window?.__SQUARE_APP_ID__) || (import.meta?.env?.VITE_SQUARE_APP_ID) || window?.SQUARE_APPLICATION_ID;
-    const locationId = (window?.__SQUARE_LOCATION_ID__) || (import.meta?.env?.VITE_SQUARE_LOCATION_ID) || window?.SQUARE_LOCATION_ID;
-    if (!appId || !locationId) {
+    const config = readSquareRuntimeConfig();
+
+    if (!config.appId || !config.locationId) {
       setError('Payment not available: missing Square configuration.');
       return () => abortController.abort();
     }
@@ -188,18 +287,39 @@ export function useSquareCard(containerId, enabled, deps = []) {
       }, 120000);
     });
 
+    const scheduleRetry = (delay = 800) => {
+      if (signal.aborted) return;
+      if (attemptsRef.current >= 5) return;
+      setTimeout(() => {
+        if (!signal.aborted) {
+          init();
+        }
+      }, delay);
+    };
+
     const init = async () => {
       try {
         if (cardRef.current || attachStartedRef.current) return;
-        setAttempts((a) => a + 1);
+        setAttempts((a) => {
+          const next = a + 1;
+          attemptsRef.current = next;
+          return next;
+        });
+        await ensureSquareSdkScript(config.sdkUrl, config.isSandbox);
         await waitForSquare();
         if (signal.aborted) return;
-        const payments = window.Square.payments(appId, locationId);
+        if (!window.Square || typeof window.Square.payments !== 'function') {
+          throw new Error('Square payments API unavailable.');
+        }
+        const payments = window.Square.payments(config.appId, config.locationId);
         paymentsRef.current = payments;
         const card = await payments.card();
         const container = await waitForContainer();
         if (signal.aborted) return;
         attachStartedRef.current = true;
+        if (container && container.childNodes && container.childNodes.length > 0) {
+          container.innerHTML = '';
+        }
         await card.attach(container);
         if (!signal.aborted) {
           cardRef.current = card;
@@ -218,21 +338,21 @@ export function useSquareCard(containerId, enabled, deps = []) {
           setError('Invalid Square App ID.');
         } else if (msg.includes('Unexpected token')) {
           setError('Payment script parse error.');
+          scheduleRetry(1500);
         } else if (msg.includes('network')) {
           setError('Network error initializing payment form.');
+          scheduleRetry(1200);
         } else if (msg === 'Payment container not found (timed out).') {
-          // Keep waiting for the form to render; retry automatically when it appears.
-          attachStartedRef.current = false;
-          setTimeout(() => {
-            if (!signal.aborted) init();
-          }, 300);
+          scheduleRetry(300);
         } else if (msg === 'Payment form failed to load (script not ready).') {
           setError(msg);
-          setTimeout(() => {
-            if (!signal.aborted) init();
-          }, 500);
+          scheduleRetry(500);
+        } else if (msg === 'Square payments API unavailable.') {
+          setError('Square payments API unavailable.');
+          scheduleRetry(800);
         } else {
           setError(msg);
+          scheduleRetry(1500);
         }
       }
     };

--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -11,6 +11,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }
 import { Input } from '../components/ui/input';
 import { Textarea } from '../components/ui/textarea';
 import { Label } from '../components/ui/label';
+import PrioritiesPie from '../components/crowdfunding/PrioritiesPie.jsx';
 import { createPortableTextComponents } from '../utils/portableTextComponents';
 import { cn } from '../lib/utils';
 
@@ -47,10 +48,30 @@ const RewardTierCard = ({ tier, onSelect, busy, selected }) => {
     ? `${pizzaCountLabel} - ${tier.title}`
     : `Pledge ${moneyLabel || '$0'} or more`;
 
+  const handleSelect = () => {
+    if (!isAvailable || busy) return;
+    if (onSelect) onSelect(tier);
+  };
+
   return (
     <Card
+      role={isAvailable ? 'button' : undefined}
+      tabIndex={isAvailable ? 0 : undefined}
+      aria-pressed={selected ? 'true' : 'false'}
+      aria-disabled={!isAvailable || busy ? 'true' : 'false'}
+      onClick={handleSelect}
+      onKeyDown={(event) => {
+        if (!isAvailable || busy) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          handleSelect();
+        }
+      }}
       className={cn(
         'card transition-colors border-slate-200 hover:border-[var(--color-accent)] focus-within:border-[var(--color-accent)]',
+        isAvailable
+          ? 'cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]'
+          : 'cursor-not-allowed opacity-60',
         selected && 'border-[var(--color-accent)] shadow-lg'
       )}
     >
@@ -76,7 +97,7 @@ const RewardTierCard = ({ tier, onSelect, busy, selected }) => {
           disabled={!isAvailable || busy}
           onClick={(event) => {
             event.stopPropagation();
-            if (isAvailable && onSelect) onSelect(tier);
+            handleSelect();
           }}
         >
           {selected ? 'Reward selected' : isAvailable ? 'Select this reward' : 'Unavailable online'}
@@ -106,6 +127,12 @@ RewardTierCard.propTypes = {
 
 // --- Main Page Component ---
 const tierIdentifier = (tier) => (tier?._id || tier?.id || tier?.title || '').toString();
+
+const UPDATE_OPTIONS = [
+  { value: 'none', label: 'No emails' },
+  { value: 'important', label: 'Important milestones' },
+  { value: 'all', label: 'All updates' },
+];
 
 const CrowdfundingPage = () => {
   const [campaignData, setCampaignData] = useState(null);
@@ -574,6 +601,7 @@ const CrowdfundingPage = () => {
               )}
               {activeTab === 'goals' && (
                 <div className="space-y-6">
+                  <PrioritiesPie />
                   {campaignData?.goals
                     ? (
                         Array.isArray(campaignData.goals)
@@ -655,113 +683,201 @@ const CrowdfundingPage = () => {
               {payError && <p className="text-sm text-red-600">{payError}</p>}
               {/* CTA button when form hidden */}
               {!showForm && (
-                <button
+                <Button
                   type="button"
                   onClick={() => setShowForm(true)}
-                  className="btn btn-primary w-full text-lg py-3"
+                  className="w-full text-lg h-12"
                 >
-                  i want pizza
-                </button>
+                  I want pizza
+                </Button>
               )}
               {showForm && (
-                <div className="space-y-4">
-                  <div className="grid grid-cols-1 gap-2">
-                    <input id="cf-name" className="input w-full" placeholder="Name" value={funderName} onChange={(e) => setFunderName(e.target.value)} />
-                    <input className="input w-full" placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
-                    <input className="input w-full" placeholder="Phone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+                <form
+                  className="space-y-6"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    if (!activeTier || typeof activeTier.amount !== 'number') return;
+                    contribute([
+                      {
+                        name: activeTier.title || 'Pizza',
+                        price: Math.round(activeTier.amount * 100),
+                        type: 'pizza',
+                        pizzaCount: pizzaQty,
+                        quantity: pizzaQty,
+                      },
+                    ]);
+                  }}
+                >
+                  <div className="grid grid-cols-1 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="cf-name">Name</Label>
+                      <Input
+                        id="cf-name"
+                        placeholder="Name"
+                        autoComplete="name"
+                        value={funderName}
+                        onChange={(e) => setFunderName(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="cf-email">Email</Label>
+                      <Input
+                        id="cf-email"
+                        type="email"
+                        autoComplete="email"
+                        placeholder="you@example.com"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="cf-phone">Phone</Label>
+                      <Input
+                        id="cf-phone"
+                        type="tel"
+                        inputMode="tel"
+                        autoComplete="tel"
+                        placeholder="(555) 555-1234"
+                        value={phone}
+                        onChange={(e) => setPhone(e.target.value)}
+                      />
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <input
-                      className="input flex-1"
-                      placeholder="Referral code (optional)"
-                      value={referralInput}
-                      onChange={(e) => setReferralInput(e.target.value)}
-                    />
-                    <button
-                      type="button"
-                      className="btn btn-secondary"
-                      disabled={!referralInput || referralState.status === 'checking'}
-                      onClick={async () => {
-                        const code = (referralInput || '').trim();
-                        if (!code) return;
-                        setReferralState({ status: 'checking', valid: false, participant: null, code });
-                        try {
-                          const resp = await fetch('/api/referrals/validate', {
-                            method: 'POST',
-                            headers: { 'content-type': 'application/json' },
-                            body: JSON.stringify({ code }),
-                          });
-                          const data = await resp.json().catch(() => ({}));
-                          if (resp.ok && data && data.valid) {
-                            setReferralState({ status: 'ok', valid: true, participant: data.participant || null, code });
-                          } else {
-                            setReferralState({ status: 'ok', valid: false, participant: null, code });
+                  <div className="space-y-2">
+                    <Label htmlFor="cf-referral">Referral code (optional)</Label>
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <Input
+                        id="cf-referral"
+                        placeholder="Referral code"
+                        value={referralInput}
+                        onChange={(e) => setReferralInput(e.target.value)}
+                        className="sm:flex-1"
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="sm:w-32"
+                        disabled={!referralInput || referralState.status === 'checking'}
+                        onClick={async () => {
+                          const code = (referralInput || '').trim();
+                          if (!code) return;
+                          setReferralState({ status: 'checking', valid: false, participant: null, code });
+                          try {
+                            const resp = await fetch('/api/referrals/validate', {
+                              method: 'POST',
+                              headers: { 'content-type': 'application/json' },
+                              body: JSON.stringify({ code }),
+                            });
+                            const data = await resp.json().catch(() => ({}));
+                            if (resp.ok && data && data.valid) {
+                              setReferralState({ status: 'ok', valid: true, participant: data.participant || null, code });
+                            } else {
+                              setReferralState({ status: 'ok', valid: false, participant: null, code });
+                            }
+                          } catch (_) {
+                            setReferralState({ status: 'error', valid: false, participant: null, code });
                           }
-                        } catch (_) {
-                          setReferralState({ status: 'error', valid: false, participant: null, code });
-                        }
-                      }}
-                    >
-                      {referralState.status === 'checking' ? 'Checking...' : 'Apply'}
-                    </button>
+                        }}
+                      >
+                        {referralState.status === 'checking' ? 'Checking...' : 'Apply'}
+                      </Button>
+                    </div>
                   </div>
                   {referralState.status === 'ok' && referralState.valid && (
-                    <p className="text-sm text-emerald-700">Code applied{referralState.participant?.name ? ` for ${referralState.participant.name}` : ''}.</p>
+                    <p className="text-sm text-emerald-700">
+                      Code applied
+                      {referralState.participant?.name ? ` for ${referralState.participant.name}` : ''}.
+                    </p>
                   )}
                   {referralState.status === 'ok' && !referralState.valid && (
                     <p className="text-sm text-red-600">That code is not valid.</p>
                   )}
+                  {referralState.status === 'error' && (
+                    <p className="text-sm text-red-600">Unable to validate that code right now.</p>
+                  )}
                   {activeTier && (
-                    <div className="flex items-center gap-3">
-                      <label htmlFor="pizza-qty" className="text-sm">Quantity</label>
-                      <input
-                        id="pizza-qty"
-                        type="number"
-                        min={1}
-                        max={50}
-                        value={pizzaQty}
-                        onChange={(e) => setPizzaQty(Math.max(1, Math.min(50, Number(e.target.value) || 1)))}
-                        className="input w-24"
-                      />
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+                      <div className="space-y-2">
+                        <Label htmlFor="pizza-qty">Quantity</Label>
+                        <Input
+                          id="pizza-qty"
+                          type="number"
+                          min={1}
+                          max={50}
+                          value={pizzaQty}
+                          onChange={(e) =>
+                            setPizzaQty(Math.max(1, Math.min(50, Number(e.target.value) || 1)))
+                          }
+                          className="w-28"
+                        />
+                      </div>
+                      {activeTierAmountLabel && (
+                        <p className="text-sm text-slate-600 sm:pb-2">
+                          Each pledge: {activeTierAmountLabel}
+                        </p>
+                      )}
                     </div>
                   )}
-                  <div>
-                    <textarea
-                      className="input w-full min-h-[80px]"
-                      placeholder="Any notes for us (optional)"
+                  <div className="space-y-2">
+                    <Label htmlFor="cf-notes">Notes (optional)</Label>
+                    <Textarea
+                      id="cf-notes"
+                      placeholder="Any notes for us"
                       value={notes}
                       onChange={(e) => setNotes(e.target.value)}
+                      className="min-h-[100px]"
                     />
                   </div>
-                  <fieldset className="space-y-1 text-sm">
-                    <legend className="font-medium mb-1">Campaign Updates</legend>
-                    <label className="flex items-center gap-2"><input type="radio" name="cf-updates" value="none" checked={notify==='none'} onChange={()=>setNotify('none')} /> <span>No emails</span></label>
-                    <label className="flex items-center gap-2"><input type="radio" name="cf-updates" value="important" checked={notify==='important'} onChange={()=>setNotify('important')} /> <span>Important milestones</span></label>
-                    <label className="flex items-center gap-2"><input type="radio" name="cf-updates" value="all" checked={notify==='all'} onChange={()=>setNotify('all')} /> <span>All updates</span></label>
-                  </fieldset>
-                  <div id="cf-card-container" className="border rounded-md p-4 bg-white min-h-[88px]" aria-label="Card payment form">
-                    {!cardLoaded && !squareConfigError && (
-                      <p className="text-sm text-gray-500">Loading secure payment form...</p>
-                    )}
-                    {squareConfigError && (
-                      <p className="text-sm text-red-600">{squareConfigError}</p>
-                    )}
+                  <div className="space-y-2">
+                    <span className="text-sm font-semibold text-slate-700">Campaign updates</span>
+                    <div className="grid gap-2 sm:grid-cols-3">
+                      {UPDATE_OPTIONS.map((option) => (
+                        <Button
+                          key={option.value}
+                          type="button"
+                          variant={notify === option.value ? 'secondary' : 'outline'}
+                          aria-pressed={notify === option.value}
+                          onClick={() => setNotify(option.value)}
+                          className="justify-center"
+                        >
+                          {option.label}
+                        </Button>
+                      ))}
+                    </div>
                   </div>
-                  {/* Inline validation hints */}
+                  <div className="space-y-2">
+                    <Label htmlFor="cf-card-container">Payment details</Label>
+                    <div
+                      id="cf-card-container"
+                      className="border rounded-md p-4 bg-white min-h-[88px]"
+                      aria-label="Card payment form"
+                    >
+                      {!cardLoaded && !squareConfigError && (
+                        <p className="text-sm text-gray-500">Loading secure payment form...</p>
+                      )}
+                      {squareConfigError && (
+                        <p className="text-sm text-red-600">{squareConfigError}</p>
+                      )}
+                    </div>
+                  </div>
                   {email && !emailValid && (
-                    <p className="text-xs text-red-600 mt-1">Please enter a valid email.</p>
+                    <p className="text-xs text-red-600">Please enter a valid email.</p>
                   )}
                   {phone && !phoneValid && (
-                    <p className="text-xs text-red-600 mt-1">Phone should have at least 10 digits.</p>
+                    <p className="text-xs text-red-600">Phone should have at least 10 digits.</p>
                   )}
-                  <button
+                  <Button
+                    type="submit"
                     disabled={!activeTier || !cardLoaded || paying || !!squareConfigError || !emailValid || !phoneValid}
-                    onClick={() => activeTier && contribute([{ name: activeTier.title || 'Pizza', price: Math.round(activeTier.amount * 100), type: 'pizza', pizzaCount: pizzaQty, quantity: pizzaQty }])}
-                    className="btn btn-primary w-full text-lg py-3 disabled:opacity-60"
+                    className="w-full text-lg h-12"
                   >
-                    {paying ? 'Processing...' : 'Buy Now'}
-                  </button>
-                </div>
+                    {paying
+                      ? 'Processing...'
+                      : activeTierAmountLabel
+                      ? `Buy ${activeTierAmountLabel}`
+                      : 'Buy now'}
+                  </Button>
+                </form>
               )}
             </div>
 


### PR DESCRIPTION
## Summary
- restyle the crowdfunding purchase form with shadcn/ui inputs, buttons, and update selectors while making reward cards clickable across the entire card
- embed a static priorities pie chart on the goals tab so the budget visualization is always available
- harden the Square Web Payments SDK loader with shared configuration helpers, script reuse, and bounded retries

## Testing
- npm run lint *(fails: ESLint configuration not migrated to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68df00cc296c83219f6f5d4a7cc48ea9