### PR TITLE
Enable scheduled digital gift cards and improve gallery pagination

### DIFF
--- a/api/store/gift-card-checkout.js
+++ b/api/store/gift-card-checkout.js
@@ -35,12 +35,6 @@ const toCents = (value) => {
   if (!Number.isFinite(num)) return 0;
   return Math.round(num * 100);
 };
-const escapeHtml = (str = '') => str
-  .replace(/&/g, '&amp;')
-  .replace(/</g, '&lt;')
-  .replace(/>/g, '&gt;')
-  .replace(/"/g, '&quot;')
-  .replace(/'/g, '&#39;');
 const formatUsd = (cents) => `$${(Number(cents || 0) / 100).toFixed(2)}`;
 const mapAddress = (address = {}) => ({
   line1: (address.line1 || '').trim(),
@@ -49,127 +43,7 @@ const mapAddress = (address = {}) => ({
   state: (address.state || '').trim(),
   postal: (address.postal || '').trim(),
 });
-
-const buildRecipientHtml = ({
-  amountLabel,
-  recipientName,
-  buyerName,
-  code,
-  note,
-  deliveryTarget,
-  cardType,
-  instructions,
-  physicalDetails,
-}) => {
-  const safeRecipient = escapeHtml(recipientName || 'friend');
-  const safeBuyer = escapeHtml(buyerName || 'someone who loves you');
-  const safeCode = escapeHtml(code || 'Pending');
-  const safeNote = note ? escapeHtml(note).replace(/\n/g, '<br />') : '';
-  const safeInstructions = (instructions || []).map((step) => `<li style="margin:6px 0;">${escapeHtml(step)}</li>`).join('');
-  const shippingBlock = physicalDetails ? `<div style="margin-top:16px; padding:16px; background:#fef3c7; border-radius:12px; color:#92400e;">
-      <strong style="display:block; font-size:15px; margin-bottom:6px;">Physical card is on the way</strong>
-      <span style="font-size:14px; line-height:20px;">${escapeHtml(physicalDetails)}</span>
-    </div>` : '';
-  const noteBlock = safeNote ? `<div style="margin-top:16px; padding:16px; background:#f8fafc; border-radius:12px;">
-      <p style="margin:0; font-size:14px; color:#334155;">${safeNote}</p>
-    </div>` : '';
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Your Local Effort Gift Card</title>
-</head>
-<body style="margin:0; padding:0; background-color:#fff8f1; font-family:'Helvetica Neue', Arial, sans-serif; color:#1f2937;">
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:linear-gradient(135deg,#fb923c,#f97316,#facc15); padding:0;">
-    <tr>
-      <td style="padding:32px 16px;">
-        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:600px; margin:0 auto; background:rgba(255,255,255,0.95); border-radius:20px; overflow:hidden; box-shadow:0 20px 45px rgba(249,115,22,0.25);">
-          <tr>
-            <td style="background:#0f172a; padding:28px; text-align:center;">
-              <img src="https://res.cloudinary.com/dokyhfvyd/image/upload/f_auto,q_auto,w_96/site/partners/logo_sticker" alt="Local Effort" width="80" height="80" style="display:inline-block; border-radius:20px; border:3px solid rgba(255,255,255,0.35);" />
-              <h1 style="margin:16px 0 0; font-size:28px; color:#f8fafc;">Local Effort Gift Card</h1>
-            </td>
-          </tr>
-          <tr>
-            <td style="padding:28px 32px;">
-              <p style="margin:0; font-size:16px;">Hey ${safeRecipient},</p>
-              <p style="font-size:16px; line-height:24px; margin:12px 0 0;">${safeBuyer} just sent you a ${escapeHtml(cardType === 'physical' ? 'Local Effort gift card (with a leather keepsake on the way!)' : 'Local Effort gift card')} worth <strong>${escapeHtml(amountLabel)}</strong>.</p>
-              ${noteBlock}
-              <div style="margin-top:20px; padding:20px; background:#ecfeff; border:2px dashed #06b6d4; border-radius:16px; text-align:center;">
-                <p style="margin:0; font-size:14px; color:#0369a1; letter-spacing:0.08em; text-transform:uppercase;">Your gift card code</p>
-                <p style="margin:12px 0 0; font-size:28px; font-weight:700; color:#0f172a; letter-spacing:0.18em;">${safeCode}</p>
-              </div>
-              <div style="margin-top:24px;">
-                <p style="margin:0 0 8px; font-weight:600; color:#dc2626; text-transform:uppercase; letter-spacing:0.06em;">How to redeem</p>
-                <ul style="margin:0; padding-left:20px; font-size:15px; color:#1f2937; list-style:circle;">
-                  ${safeInstructions}
-                </ul>
-              </div>
-              ${shippingBlock}
-              <p style="margin:24px 0 0; font-size:14px; color:#475569;">This email was sent to ${escapeHtml(deliveryTarget === 'recipient' ? 'you directly' : 'the buyer')} so we can make sure your delicious plans go smoothly.</p>
-            </td>
-          </tr>
-          <tr>
-            <td style="background:#0f172a; padding:20px 28px; text-align:center; color:#e2e8f0;">
-              <p style="margin:0; font-size:14px;">Need to schedule your experience? Email <a href="mailto:hello@localeffortfood.com" style="color:#facc15; text-decoration:none; font-weight:600;">hello@localeffortfood.com</a> and we'll craft a menu together.</p>
-              <div style="margin-top:14px;">
-                <img src="https://res.cloudinary.com/dokyhfvyd/image/upload/f_auto,q_auto,w_120/vjuesai2mxfavpq9d2df" alt="Local Effort feast" width="120" style="border-radius:12px; box-shadow:0 5px 18px rgba(15,23,42,0.45);" />
-              </div>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
-</html>`;
-};
-
-const buildRecipientText = ({ amountLabel, recipientName, buyerName, code, instructions, note, cardType, physicalDetails }) => {
-  const intro = `Hey ${recipientName || 'there'},\n\n${buyerName || 'A friend'} just sent you a ${cardType === 'physical' ? 'Local Effort gift card (with a leather keepsake headed your way)' : 'Local Effort gift card'} worth ${amountLabel}.`;
-  const noteSection = note ? `\n\nTheir note: ${note}` : '';
-  const steps = (instructions || []).map((step, idx) => `${idx + 1}. ${step}`).join('\n');
-  const shipping = physicalDetails ? `\n\nShipping update: ${physicalDetails}` : '';
-  return `${intro}${noteSection}\n\nGift card code: ${code || 'Pending'}\n\nHow to redeem:\n${steps}${shipping}\n\nQuestions? Email hello@localeffortfood.com.`;
-};
-
-const buildBuyerText = ({ amountLabel, buyerName, recipientName, code, cardType, shippingSummary }) => {
-  return `Hi ${buyerName || 'there'},\n\nThanks for purchasing a Local Effort gift card for ${recipientName || 'your guest'}!\n\nDetails:\nAmount: ${amountLabel}\nType: ${cardType === 'physical' ? 'Physical card with leather holder' : 'Digital'}\nGift card code: ${code || 'Pending'}${shippingSummary ? `\nShipping: ${shippingSummary}` : ''}\n\nWe'll follow up if we need anything else. Thanks for supporting local food!`;
-};
-
-const buildTeamText = ({ amountLabel, buyer, recipient, note, deliveryTarget, cardType, shipping, paymentId, giftCardId, code }) => {
-  const lines = [
-    `Amount: ${amountLabel}`,
-    `Payment ID: ${paymentId || 'n/a'}`,
-    `Gift Card ID: ${giftCardId || 'n/a'}`,
-    `Gift Card Code: ${code || 'n/a'}`,
-    `Card Type: ${cardType}`,
-    `Delivery Target: ${deliveryTarget}`,
-    '',
-    'Buyer:',
-    `  Name: ${buyer?.name || ''}`,
-    `  Email: ${buyer?.email || ''}`,
-    `  Phone: ${buyer?.phone || ''}`,
-    '',
-    'Recipient:',
-    `  Name: ${recipient?.name || ''}`,
-    `  Email: ${recipient?.email || ''}`,
-    `  Phone: ${recipient?.phone || ''}`,
-  ];
-  if (shipping && shipping.address) {
-    const addr = shipping.address;
-    lines.push('', 'Shipping Address:');
-    lines.push(`  ${addr.line1}`);
-    if (addr.line2) lines.push(`  ${addr.line2}`);
-    lines.push(`  ${addr.city}, ${addr.state} ${addr.postal}`);
-    lines.push(`  Ship To: ${shipping.shipTo}`);
-  }
-  if (note) {
-    lines.push('', 'Recipient note:', note);
-  }
-  return lines.join('\n');
-};
+const { buildRecipientHtml, buildRecipientText, buildBuyerText, buildTeamText } = require('./gift-card-email');
 
 const upsertBrevoContact = async ({ email, attributes }) => {
   if (!BREVO_API_KEY || !email) return;
@@ -194,7 +68,7 @@ const upsertBrevoContact = async ({ email, attributes }) => {
   }
 };
 
-module.exports = async (req, res) => {
+const giftCardCheckout = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
@@ -204,7 +78,7 @@ module.exports = async (req, res) => {
   if (!LOCATION_ID) return res.status(500).json({ error: 'Square location missing' });
 
   try {
-    const { amount, token, buyer = {}, recipient = {}, note = '', deliveryTarget = 'recipient', cardType = 'digital', shipping = null } = req.body || {};
+    const { amount, token, buyer = {}, recipient = {}, note = '', deliveryTarget = 'recipient', cardType = 'digital', shipping = null, sendOn = null } = req.body || {};
     const amountCents = toCents(amount);
     const buyerName = (buyer.name || '').trim();
     const buyerEmail = (buyer.email || '').trim();
@@ -212,6 +86,11 @@ module.exports = async (req, res) => {
     const recipientName = (recipient.name || '').trim();
     const recipientEmail = (recipient.email || '').trim();
     const recipientPhone = (recipient.phone || '').trim();
+    const isDigital = cardType !== 'physical';
+    const sendOnDate = sendOn ? new Date(sendOn) : null;
+    if (sendOn && Number.isNaN(sendOnDate?.getTime())) {
+      return res.status(400).json({ error: 'Invalid send date' });
+    }
 
     if (!token) return res.status(400).json({ error: 'Missing payment token' });
     if (!amountCents || amountCents < 5000) return res.status(400).json({ error: 'Amount must be at least $50' });
@@ -220,6 +99,16 @@ module.exports = async (req, res) => {
       return res.status(400).json({ error: 'Recipient email required when delivering to recipient' });
     }
     const wantsPhysical = cardType === 'physical';
+    if (sendOnDate && wantsPhysical) {
+      return res.status(400).json({ error: 'Scheduled delivery is only available for digital gift cards' });
+    }
+    if (sendOnDate) {
+      const now = Date.now();
+      const minDelay = 5 * 60 * 1000; // 5 minutes buffer for scheduled delivery
+      if (sendOnDate.getTime() <= now + minDelay) {
+        return res.status(400).json({ error: 'Send date must be at least 5 minutes in the future' });
+      }
+    }
     if (wantsPhysical && amountCents < 25000) {
       return res.status(400).json({ error: 'Physical gift cards require $250 or more' });
     }
@@ -297,6 +186,7 @@ module.exports = async (req, res) => {
       paymentId,
       giftCardId: giftCard.id,
       code,
+      sendOn: sendOnDate ? sendOnDate.toISOString() : null,
     };
 
     if (db) {
@@ -325,16 +215,18 @@ module.exports = async (req, res) => {
         cardType: payload.cardType,
         instructions,
         physicalDetails,
+        sendOn: sendOnDate ? sendOnDate.toISOString() : null,
       });
-      const recipientText = buildRecipientText({ amountLabel, recipientName, buyerName, code, instructions, note, cardType: payload.cardType, physicalDetails });
+      const recipientText = buildRecipientText({ amountLabel, recipientName, buyerName, code, instructions, note, cardType: payload.cardType, physicalDetails, sendOn: sendOnDate ? sendOnDate.toISOString() : null });
 
-      const buyerText = buildBuyerText({ amountLabel, buyerName, recipientName, code, cardType: payload.cardType, shippingSummary: physicalDetails });
+      const buyerText = buildBuyerText({ amountLabel, buyerName, recipientName, code, cardType: payload.cardType, shippingSummary: physicalDetails, sendOn: sendOnDate ? sendOnDate.toISOString() : null, deliveryTarget });
 
-      const teamText = buildTeamText({ amountLabel, buyer, recipient, note, deliveryTarget, cardType: payload.cardType, shipping: payload.shipping, paymentId, giftCardId: giftCard.id, code });
+      const teamText = buildTeamText({ amountLabel, buyer, recipient, note, deliveryTarget, cardType: payload.cardType, shipping: payload.shipping, paymentId, giftCardId: giftCard.id, code, sendOn: sendOnDate ? sendOnDate.toISOString() : null });
 
       // Send to recipient/buyer target
       if (deliveryEmail) {
         try {
+          const scheduledAt = sendOnDate && isDigital && deliveryTarget === 'recipient' ? sendOnDate.toISOString() : null;
           await fetch('https://api.brevo.com/v3/smtp/email', {
             method: 'POST',
             headers,
@@ -344,6 +236,7 @@ module.exports = async (req, res) => {
               subject: `${buyerName || 'A friend'} sent you a Local Effort gift card`,
               htmlContent: recipientHtml,
               textContent: recipientText,
+              ...(scheduledAt ? { scheduledAt } : {}),
             }),
           });
         } catch (err) {
@@ -413,7 +306,7 @@ module.exports = async (req, res) => {
       }
     }
 
-    return res.status(200).json({ ok: true, code, amount: amountCents, paymentId, giftCardId: giftCard.id, cardType: wantsPhysical ? 'physical' : 'digital' });
+    return res.status(200).json({ ok: true, code, amount: amountCents, paymentId, giftCardId: giftCard.id, cardType: wantsPhysical ? 'physical' : 'digital', sendOn: sendOnDate ? sendOnDate.toISOString() : null });
   } catch (err) {
     const details = err?.errors ? JSON.stringify(err.errors) : err?.message || 'Gift card checkout failed';
     if (process.env.NODE_ENV !== 'production') {
@@ -422,3 +315,5 @@ module.exports = async (req, res) => {
     return res.status(500).json({ error: details });
   }
 };
+
+module.exports = giftCardCheckout;

--- a/api/store/gift-card-email.js
+++ b/api/store/gift-card-email.js
@@ -1,0 +1,161 @@
+const escapeHtml = (str = '') => str
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
+const formatSchedule = (isoString) => {
+  if (!isoString) return '';
+  try {
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return '';
+    return new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'America/Chicago',
+    }).format(date);
+  } catch (err) {
+    return '';
+  }
+};
+
+const buildRecipientHtml = ({
+  amountLabel,
+  recipientName,
+  buyerName,
+  code,
+  note,
+  deliveryTarget,
+  cardType,
+  instructions,
+  physicalDetails,
+  sendOn,
+}) => {
+  const safeRecipient = escapeHtml(recipientName || 'friend');
+  const safeBuyer = escapeHtml(buyerName || 'someone who loves you');
+  const safeCode = escapeHtml(code || 'Pending');
+  const safeNote = note ? escapeHtml(note).replace(/\n/g, '<br />') : '';
+  const safeInstructions = (instructions || []).map((step) => `<li style="margin:6px 0;">${escapeHtml(step)}</li>`).join('');
+  const shippingBlock = physicalDetails ? `<div style="margin-top:16px; padding:16px; background:#fef3c7; border-radius:12px; color:#92400e;">
+      <strong style="display:block; font-size:15px; margin-bottom:6px;">Physical card is on the way</strong>
+      <span style="font-size:14px; line-height:20px;">${escapeHtml(physicalDetails)}</span>
+    </div>` : '';
+  const noteBlock = safeNote ? `<div style="margin-top:16px; padding:16px; background:#f8fafc; border-radius:12px;">
+      <p style="margin:0; font-size:14px; color:#334155;">${safeNote}</p>
+    </div>` : '';
+  const scheduledLine = sendOn ? `<p style="margin:12px 0 0; font-size:13px; color:#2563eb;">Scheduled delivery: ${escapeHtml(formatSchedule(sendOn) || sendOn)}</p>` : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Your Local Effort Gift Card</title>
+</head>
+<body style="margin:0; padding:0; background-color:#fff8f1; font-family:'Helvetica Neue', Arial, sans-serif; color:#1f2937;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:linear-gradient(135deg,#fb923c,#f97316,#facc15); padding:0;">
+    <tr>
+      <td style="padding:32px 16px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:600px; margin:0 auto; background:rgba(255,255,255,0.95); border-radius:20px; overflow:hidden; box-shadow:0 20px 45px rgba(249,115,22,0.25);">
+          <tr>
+            <td style="background:#0f172a; padding:28px; text-align:center;">
+              <img src="https://res.cloudinary.com/dokyhfvyd/image/upload/f_auto,q_auto,w_96/site/partners/logo_sticker" alt="Local Effort" width="80" height="80" style="display:inline-block; border-radius:20px; border:3px solid rgba(255,255,255,0.35);" />
+              <h1 style="margin:16px 0 0; font-size:28px; color:#f8fafc;">Local Effort Gift Card</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 32px;">
+              <p style="margin:0; font-size:16px;">Hey ${safeRecipient},</p>
+              <p style="font-size:16px; line-height:24px; margin:12px 0 0;">${safeBuyer} just sent you a ${escapeHtml(cardType === 'physical' ? 'Local Effort gift card (with a leather keepsake on the way!)' : 'Local Effort gift card')} worth <strong>${escapeHtml(amountLabel)}</strong>.</p>
+              ${scheduledLine}
+              ${noteBlock}
+              <div style="margin-top:20px; padding:20px; background:#ecfeff; border:2px dashed #06b6d4; border-radius:16px; text-align:center;">
+                <p style="margin:0; font-size:14px; color:#0369a1; letter-spacing:0.08em; text-transform:uppercase;">Your gift card code</p>
+                <p style="margin:12px 0 0; font-size:28px; font-weight:700; color:#0f172a; letter-spacing:0.18em;">${safeCode}</p>
+              </div>
+              <div style="margin-top:24px;">
+                <p style="margin:0 0 8px; font-weight:600; color:#dc2626; text-transform:uppercase; letter-spacing:0.06em;">How to redeem</p>
+                <ul style="margin:0; padding-left:20px; font-size:15px; color:#1f2937; list-style:circle;">
+                  ${safeInstructions}
+                </ul>
+              </div>
+              ${shippingBlock}
+              <p style="margin:24px 0 0; font-size:14px; color:#475569;">This email was sent to ${escapeHtml(deliveryTarget === 'recipient' ? 'you directly' : 'the buyer')} so we can make sure your delicious plans go smoothly.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="background:#0f172a; padding:20px 28px; text-align:center; color:#e2e8f0;">
+              <p style="margin:0; font-size:14px;">Need to schedule your experience? Email <a href="mailto:hello@localeffortfood.com" style="color:#facc15; text-decoration:none; font-weight:600;">hello@localeffortfood.com</a> and we'll craft a menu together.</p>
+              <div style="margin-top:14px;">
+                <img src="https://res.cloudinary.com/dokyhfvyd/image/upload/f_auto,q_auto,w_120/vjuesai2mxfavpq9d2df" alt="Local Effort feast" width="120" style="border-radius:12px; box-shadow:0 5px 18px rgba(15,23,42,0.45);" />
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+};
+
+const buildRecipientText = ({ amountLabel, recipientName, buyerName, code, instructions, note, cardType, physicalDetails, sendOn }) => {
+  const intro = `Hey ${recipientName || 'there'},\n\n${buyerName || 'A friend'} just sent you a ${cardType === 'physical' ? 'Local Effort gift card (with a leather keepsake headed your way)' : 'Local Effort gift card'} worth ${amountLabel}.`;
+  const noteSection = note ? `\n\nTheir note: ${note}` : '';
+  const steps = (instructions || []).map((step, idx) => `${idx + 1}. ${step}`).join('\n');
+  const shipping = physicalDetails ? `\n\nShipping update: ${physicalDetails}` : '';
+  const schedule = sendOn ? `\n\nScheduled delivery: ${formatSchedule(sendOn) || sendOn}` : '';
+  return `${intro}${noteSection}${schedule}\n\nGift card code: ${code || 'Pending'}\n\nHow to redeem:\n${steps}${shipping}\n\nQuestions? Email hello@localeffortfood.com.`;
+};
+
+const buildBuyerText = ({ amountLabel, buyerName, recipientName, code, cardType, shippingSummary, sendOn, deliveryTarget }) => {
+  const schedule = sendOn && cardType !== 'physical'
+    ? `\nScheduled delivery: ${formatSchedule(sendOn) || sendOn} (${deliveryTarget === 'recipient' ? 'recipient email' : 'buyer email'})`
+    : '';
+  return `Hi ${buyerName || 'there'},\n\nThanks for purchasing a Local Effort gift card for ${recipientName || 'your guest'}!\n\nDetails:\nAmount: ${amountLabel}\nType: ${cardType === 'physical' ? 'Physical card with leather holder' : 'Digital'}${schedule}\nGift card code: ${code || 'Pending'}${shippingSummary ? `\nShipping: ${shippingSummary}` : ''}\n\nWe'll follow up if we need anything else. Thanks for supporting local food!`;
+};
+
+const buildTeamText = ({ amountLabel, buyer, recipient, note, deliveryTarget, cardType, shipping, paymentId, giftCardId, code, sendOn }) => {
+  const lines = [
+    `Amount: ${amountLabel}`,
+    `Payment ID: ${paymentId || 'n/a'}`,
+    `Gift Card ID: ${giftCardId || 'n/a'}`,
+    `Gift Card Code: ${code || 'n/a'}`,
+    `Card Type: ${cardType}`,
+    `Delivery Target: ${deliveryTarget}`,
+    '',
+    'Buyer:',
+    `  Name: ${buyer?.name || ''}`,
+    `  Email: ${buyer?.email || ''}`,
+    `  Phone: ${buyer?.phone || ''}`,
+    '',
+    'Recipient:',
+    `  Name: ${recipient?.name || ''}`,
+    `  Email: ${recipient?.email || ''}`,
+    `  Phone: ${recipient?.phone || ''}`,
+  ];
+  if (sendOn && cardType !== 'physical') {
+    lines.push(`Scheduled Send: ${formatSchedule(sendOn) || sendOn}`);
+  }
+  if (shipping && shipping.address) {
+    const addr = shipping.address;
+    lines.push('', 'Shipping Address:');
+    lines.push(`  ${addr.line1}`);
+    if (addr.line2) lines.push(`  ${addr.line2}`);
+    lines.push(`  ${addr.city}, ${addr.state} ${addr.postal}`);
+    lines.push(`  Ship To: ${shipping.shipTo}`);
+  }
+  if (note) {
+    lines.push('', 'Recipient note:', note);
+  }
+  return lines.join('\n');
+};
+
+module.exports = {
+  escapeHtml,
+  formatSchedule,
+  buildRecipientHtml,
+  buildRecipientText,
+  buildBuyerText,
+  buildTeamText,
+};

--- a/emails/digital-gift-card-demo.html
+++ b/emails/digital-gift-card-demo.html
@@ -1,0 +1,54 @@
+<!-- Auto-generated demo for stakeholders. Run `node scripts/render-gift-card-email.js` to refresh. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Your Local Effort Gift Card</title>
+</head>
+<body style="margin:0; padding:0; background-color:#fff8f1; font-family:'Helvetica Neue', Arial, sans-serif; color:#1f2937;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:linear-gradient(135deg,#fb923c,#f97316,#facc15); padding:0;">
+    <tr>
+      <td style="padding:32px 16px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:600px; margin:0 auto; background:rgba(255,255,255,0.95); border-radius:20px; overflow:hidden; box-shadow:0 20px 45px rgba(249,115,22,0.25);">
+          <tr>
+            <td style="background:#0f172a; padding:28px; text-align:center;">
+              <img src="https://res.cloudinary.com/dokyhfvyd/image/upload/f_auto,q_auto,w_96/site/partners/logo_sticker" alt="Local Effort" width="80" height="80" style="display:inline-block; border-radius:20px; border:3px solid rgba(255,255,255,0.35);" />
+              <h1 style="margin:16px 0 0; font-size:28px; color:#f8fafc;">Local Effort Gift Card</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 32px;">
+              <p style="margin:0; font-size:16px;">Hey Jordan Guest,</p>
+              <p style="font-size:16px; line-height:24px; margin:12px 0 0;">Taylor Host just sent you a Local Effort gift card worth <strong>$250.00</strong>.</p>
+              <p style="margin:12px 0 0; font-size:13px; color:#2563eb;">Scheduled delivery: Dec 24, 2024, 9:00 AM</p>
+              <div style="margin-top:16px; padding:16px; background:#f8fafc; border-radius:12px;">
+      <p style="margin:0; font-size:14px; color:#334155;">Cannot wait to celebrate with you soon! Save this for a cozy dinner. ❤️</p>
+    </div>
+              <div style="margin-top:20px; padding:20px; background:#ecfeff; border:2px dashed #06b6d4; border-radius:16px; text-align:center;">
+                <p style="margin:0; font-size:14px; color:#0369a1; letter-spacing:0.08em; text-transform:uppercase;">Your gift card code</p>
+                <p style="margin:12px 0 0; font-size:28px; font-weight:700; color:#0f172a; letter-spacing:0.18em;">LOCAL-LOVE-2024</p>
+              </div>
+              <div style="margin-top:24px;">
+                <p style="margin:0 0 8px; font-weight:600; color:#dc2626; text-transform:uppercase; letter-spacing:0.06em;">How to redeem</p>
+                <ul style="margin:0; padding-left:20px; font-size:15px; color:#1f2937; list-style:circle;">
+                  <li style="margin:6px 0;">Reply to this email or message hello@localeffortfood.com to plan your menu.</li><li style="margin:6px 0;">Share this gift code when you book your experience.</li><li style="margin:6px 0;">Get ready for seasonal plates crafted just for you.</li>
+                </ul>
+              </div>
+              
+              <p style="margin:24px 0 0; font-size:14px; color:#475569;">This email was sent to you directly so we can make sure your delicious plans go smoothly.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="background:#0f172a; padding:20px 28px; text-align:center; color:#e2e8f0;">
+              <p style="margin:0; font-size:14px;">Need to schedule your experience? Email <a href="mailto:hello@localeffortfood.com" style="color:#facc15; text-decoration:none; font-weight:600;">hello@localeffortfood.com</a> and we'll craft a menu together.</p>
+              <div style="margin-top:14px;">
+                <img src="https://res.cloudinary.com/dokyhfvyd/image/upload/f_auto,q_auto,w_120/vjuesai2mxfavpq9d2df" alt="Local Effort feast" width="120" style="border-radius:12px; box-shadow:0 5px 18px rgba(15,23,42,0.45);" />
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/scripts/render-gift-card-email.js
+++ b/scripts/render-gift-card-email.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const {
+  buildRecipientHtml,
+} = require('../api/store/gift-card-email');
+
+const outputPath = path.resolve(__dirname, '../emails/digital-gift-card-demo.html');
+
+const sample = {
+  amountLabel: '$250.00',
+  recipientName: 'Jordan Guest',
+  buyerName: 'Taylor Host',
+  code: 'LOCAL-LOVE-2024',
+  note: 'Cannot wait to celebrate with you soon! Save this for a cozy dinner. ❤️',
+  deliveryTarget: 'recipient',
+  cardType: 'digital',
+  instructions: [
+    'Reply to this email or message hello@localeffortfood.com to plan your menu.',
+    'Share this gift code when you book your experience.',
+    'Get ready for seasonal plates crafted just for you.',
+  ],
+  physicalDetails: null,
+  sendOn: new Date('2024-12-24T15:00:00.000Z').toISOString(),
+};
+
+const html = buildRecipientHtml(sample);
+
+const header = '<!-- Auto-generated demo for stakeholders. Run `node scripts/render-gift-card-email.js` to refresh. -->\n';
+
+fs.writeFileSync(outputPath, `${header}${html}`);
+
+console.log(`Gift card email demo saved to ${outputPath}`);

--- a/src/components/home/GiftCardDialog.jsx
+++ b/src/components/home/GiftCardDialog.jsx
@@ -14,6 +14,7 @@ const initialForm = {
   cardType: "digital",
   deliveryTarget: "recipient",
   shipTo: "recipient",
+  sendOn: "",
   buyerName: "",
   buyerEmail: "",
   buyerPhone: "",
@@ -92,6 +93,12 @@ const GiftCardDialog = ({ className = "" }) => {
     }
   }, [canChoosePhysical, form.cardType]);
 
+  useEffect(() => {
+    if (form.cardType !== "digital" || form.deliveryTarget !== "recipient") {
+      setForm((prev) => (prev.sendOn ? { ...prev, sendOn: "" } : prev));
+    }
+  }, [form.cardType, form.deliveryTarget]);
+
   const handleAmountClick = (value) => {
     setForm((prev) => ({ ...prev, amount: value, customAmount: "" }));
   };
@@ -111,7 +118,7 @@ const GiftCardDialog = ({ className = "" }) => {
       return;
     }
 
-    const { buyerName, buyerEmail, recipientEmail, cardType, deliveryTarget } = form;
+    const { buyerName, buyerEmail, recipientEmail, cardType, deliveryTarget, sendOn } = form;
     if (!buyerName.trim() || !buyerEmail.trim()) {
       setError("Buyer name and email are required.");
       return;
@@ -119,6 +126,26 @@ const GiftCardDialog = ({ className = "" }) => {
     if (deliveryTarget === "recipient" && !recipientEmail.trim()) {
       setError("Recipient email is required when sending directly to them.");
       return;
+    }
+    if (sendOn && cardType !== "digital") {
+      setError("Scheduled delivery is only available for digital gift cards.");
+      return;
+    }
+
+    let sendOnIso = null;
+    if (sendOn) {
+      const parsed = new Date(sendOn);
+      if (Number.isNaN(parsed.getTime())) {
+        setError("Please provide a valid send date.");
+        return;
+      }
+      const now = new Date();
+      const minAhead = 5 * 60 * 1000;
+      if (parsed.getTime() <= now.getTime() + minAhead) {
+        setError("Please choose a send time at least 5 minutes from now.");
+        return;
+      }
+      sendOnIso = parsed.toISOString();
     }
     if (cardType === "physical") {
       if (!form.shippingLine1.trim() || !form.shippingCity.trim() || !form.shippingState.trim() || !form.shippingPostal.trim()) {
@@ -147,6 +174,7 @@ const GiftCardDialog = ({ className = "" }) => {
           email: form.recipientEmail,
           phone: form.recipientPhone,
         },
+        sendOn: sendOnIso,
         shipping: cardType === "physical"
           ? {
               shipTo: form.shipTo,
@@ -177,6 +205,8 @@ const GiftCardDialog = ({ className = "" }) => {
         code: data.code,
         amount: data.amount,
         cardType: data.cardType,
+        deliveryTarget,
+        sendOn: data.sendOn || sendOnIso,
       });
       setStatus("success");
     } catch (err) {
@@ -187,39 +217,70 @@ const GiftCardDialog = ({ className = "" }) => {
 
   const amountLabel = useMemo(() => `$${amountValue.toFixed(2)}`, [amountValue]);
   const disableSubmit = !cardLoaded || status === "processing";
+  const minSendOn = useMemo(() => {
+    const base = new Date();
+    base.setMinutes(base.getMinutes() + 10);
+    return base.toISOString().slice(0, 16);
+  }, [open]);
 
-  const renderSuccess = () => (
-    <div className="space-y-6">
-      <div className="rounded-2xl border border-emerald-100 bg-emerald-50/80 p-6 text-center">
-        <Sparkles className="mx-auto h-10 w-10 text-emerald-500" />
-        <h3 className="mt-4 text-2xl font-semibold text-emerald-700">Gift card sent!</h3>
-        <p className="text-sm text-emerald-700">We just delivered the gift card email and a confirmation receipt. Save this code for your records.</p>
-        <div className="mt-4 rounded-xl border border-emerald-200 bg-white px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-emerald-500">Gift card code</p>
-          <p className="mt-2 text-2xl font-mono font-bold tracking-widest text-slate-900">{success?.code || "Pending"}</p>
+  const formatDateTime = (isoString) => {
+    if (!isoString) return "";
+    try {
+      const date = new Date(isoString);
+      if (Number.isNaN(date.getTime())) return "";
+      return new Intl.DateTimeFormat(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(date);
+    } catch (err) {
+      return "";
+    }
+  };
+
+  const renderSuccess = () => {
+    const scheduledCopy = success?.sendOn ? formatDateTime(success.sendOn) : "";
+    return (
+      <div className="space-y-6">
+        <div className="rounded-2xl border border-emerald-100 bg-emerald-50/80 p-6 text-center">
+          <Sparkles className="mx-auto h-10 w-10 text-emerald-500" />
+          <h3 className="mt-4 text-2xl font-semibold text-emerald-700">
+            {success?.sendOn ? "Gift card scheduled!" : "Gift card sent!"}
+          </h3>
+          <p className="text-sm text-emerald-700">
+            {success?.sendOn
+              ? `We'll deliver the gift card email to the ${success?.deliveryTarget === "recipient" ? "recipient" : "buyer"} on ${scheduledCopy}.`
+              : "We just delivered the gift card email and a confirmation receipt. Save this code for your records."}
+          </p>
+          <div className="mt-4 rounded-xl border border-emerald-200 bg-white px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-emerald-500">Gift card code</p>
+            <p className="mt-2 text-2xl font-mono font-bold tracking-widest text-slate-900">{success?.code || "Pending"}</p>
+          </div>
+          <p className="mt-4 text-sm text-slate-600">Amount: <span className="font-semibold">{amountLabel}</span> - Type: {success?.cardType === "physical" ? "Leather physical card + digital code" : "Digital"}</p>
+          {success?.sendOn && (
+            <p className="text-xs text-slate-500">You'll also get a reminder email when it goes out.</p>
+          )}
+          <button
+            type="button"
+            className="mt-5 inline-flex items-center justify-center rounded-full border border-emerald-400 px-4 py-2 text-sm font-semibold text-emerald-600 transition hover:bg-emerald-100"
+            onClick={() => {
+              if (success?.code) navigator.clipboard?.writeText(success.code).catch(() => {});
+            }}
+          >
+            Copy code
+          </button>
         </div>
-        <p className="mt-4 text-sm text-slate-600">Amount: <span className="font-semibold">{amountLabel}</span> - Type: {success?.cardType === "physical" ? "Leather physical card + digital code" : "Digital"}</p>
-        <button
-          type="button"
-          className="mt-5 inline-flex items-center justify-center rounded-full border border-emerald-400 px-4 py-2 text-sm font-semibold text-emerald-600 transition hover:bg-emerald-100"
-          onClick={() => {
-            if (success?.code) navigator.clipboard?.writeText(success.code).catch(() => {});
-          }}
-        >
-          Copy code
-        </button>
+        <DialogFooter>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => setOpen(false)}
+          >
+            Close
+          </button>
+        </DialogFooter>
       </div>
-      <DialogFooter>
-        <button
-          type="button"
-          className="btn btn-primary"
-          onClick={() => setOpen(false)}
-        >
-          Close
-        </button>
-      </DialogFooter>
-    </div>
-  );
+    );
+  };
 
   return (
     <>
@@ -414,6 +475,22 @@ const GiftCardDialog = ({ className = "" }) => {
                   <label className="label" htmlFor="gift-recipient-email">Recipient email</label>
                   <input id="gift-recipient-email" className="input" type="email" value={form.recipientEmail} onChange={handleInputChange("recipientEmail")} placeholder="hello@friend.com" />
                 </div>
+                {form.cardType === "digital" && form.deliveryTarget === "recipient" && (
+                  <div>
+                    <label className="label" htmlFor="gift-send-on">Send on (optional)</label>
+                    <input
+                      id="gift-send-on"
+                      type="datetime-local"
+                      className="input"
+                      value={form.sendOn}
+                      onChange={handleInputChange("sendOn")}
+                      min={minSendOn}
+                    />
+                    <p className="mt-1 text-xs text-slate-500">
+                      Choose a future date and time (your local timezone) to deliver the email automatically. Leave blank to send it right away.
+                    </p>
+                  </div>
+                )}
                 <div>
                   <label className="label" htmlFor="gift-recipient-phone">Recipient phone (optional)</label>
                   <input id="gift-recipient-phone" className="input" value={form.recipientPhone} onChange={handleInputChange("recipientPhone")} />

--- a/src/pages/GalleryPage.jsx
+++ b/src/pages/GalleryPage.jsx
@@ -8,6 +8,7 @@ const GalleryPage = () => {
   const [nextCursor, setNextCursor] = useState(null);
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null);
   const staticFallback = [
@@ -74,7 +75,12 @@ const GalleryPage = () => {
   }, []);
 
   const fetchImages = useCallback(async (opts = {}) => {
-    const { append = false, cursor = null, signal } = opts;
+    const { append = false, cursor = null, signal, mode = 'initial' } = opts;
+    if (mode === 'loadMore') {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+    }
     const q = query ? `query=${encodeURIComponent(query)}&` : '';
     const c = cursor ? `next_cursor=${encodeURIComponent(cursor)}&` : '';
     const apiUrl = `/api/search-images?${q}${c}per_page=${PAGE_SIZE}`;
@@ -105,20 +111,28 @@ const GalleryPage = () => {
       } catch (err) {
         if (err.name === 'AbortError') return;
         console.error('Error fetching images:', err);
-        // Attempt a static fallback so the gallery still shows something
-        try {
-          const fallback = await tryLoadFallback();
-          if (fallback && fallback.length) {
-            setImages(shuffle(fallback));
-            setError('Showing fallback images while the gallery API is unavailable.');
-          } else {
+        if (mode === 'loadMore') {
+          setError(err.message || String(err));
+        } else {
+          // Attempt a static fallback so the gallery still shows something
+          try {
+            const fallback = await tryLoadFallback();
+            if (fallback && fallback.length) {
+              setImages(shuffle(fallback));
+              setError('Showing fallback images while the gallery API is unavailable.');
+            } else {
+              setError(err.message || String(err));
+            }
+          } catch (_) {
             setError(err.message || String(err));
           }
-        } catch (_) {
-          setError(err.message || String(err));
         }
       } finally {
-        setLoading(false);
+        if (mode === 'loadMore') {
+          setLoadingMore(false);
+        } else {
+          setLoading(false);
+        }
       }
   }, [query, shuffle, tryLoadFallback]);
 
@@ -165,10 +179,9 @@ const GalleryPage = () => {
   useEffect(() => {
     const controller = new AbortController();
     const handler = setTimeout(() => {
-      setLoading(true);
       setError(null);
       setNextCursor(null);
-      fetchImages({ append: false, cursor: null, signal: controller.signal });
+      fetchImages({ append: false, cursor: null, signal: controller.signal, mode: 'initial' });
     }, 300);
     return () => {
       clearTimeout(handler);
@@ -361,15 +374,14 @@ const GalleryPage = () => {
                 <button
                   type="button"
                   onClick={() => {
-                    if (loading) return; // prevent double clicks
-                    setLoading(true);
+                    if (loadingMore) return; // prevent double clicks
                     setError(null);
-                    fetchImages({ append: true, cursor: nextCursor });
+                    fetchImages({ append: true, cursor: nextCursor, mode: 'loadMore' });
                   }}
                   className="px-4 py-2 rounded bg-black text-white hover:bg-neutral-800 disabled:opacity-50"
-                  disabled={loading}
+                  disabled={loading || loadingMore}
                 >
-                  {loading ? 'Loading…' : 'Load more'}
+                  {loadingMore ? 'Loading…' : 'Load more'}
                 </button>
               </div>
             )}


### PR DESCRIPTION
## Summary
- add a delivery scheduler to the gift card dialog, including success messaging for upcoming sends
- update the gift card checkout API to accept scheduled sends, share reusable email builders, and generate a demo HTML email
- refine the gallery page "load more" behavior to append results without reloading or jumping to the top

## Testing
- `npm run lint` *(fails: ESLint configuration missing in repo image)*

------
https://chatgpt.com/codex/tasks/task_e_68df0baecd548321973ad72c2a266007