### PR TITLE
Fix duplicate FoodTruck lazy import definition

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,6 @@ const WeeklyPost = lazy(() => import('./pages/WeeklyPost'));
 const GalleryPage = lazy(() => import('./pages/GalleryPage'));
 // --- NEW: Lazily import the MealPrepPage ---
 const MealPrepPage = lazy(() => import('./pages/MealPrepPage'));
-const FoodTruckPage = lazy(() => import('./pages/FoodTruckPage'));
 // --- NEW: Sale page ---
 const SalePage = lazy(() => import('./pages/SalePage'));
 const ProductPage = lazy(() => import('./pages/ProductPage'));


### PR DESCRIPTION
## Summary
- remove the duplicate FoodTruckPage lazy import in App.jsx that caused build-time redeclaration errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df12e099c8832181b27b50c25300d5