### PR TITLE
Temporarily hide food truck page

### DIFF
--- a/prerender/food-truck/index.html
+++ b/prerender/food-truck/index.html
@@ -2,69 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-<!-- Favicon temporarily removed -->
-<link rel="manifest" href="/manifest.json" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Local Effort | Personal Chef & Event Catering in Roseville, MN"
-    />
-    <!-- Development-friendly Content Security Policy: allow local dev servers and backend -->
-    <meta http-equiv="Content-Security-Policy" content="
-      default-src 'self' http: https: 'unsafe-inline' 'unsafe-eval';
-      img-src 'self' data: http://localhost:3001 http://localhost:5173 https:;
-      script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:5173 https:;
-      connect-src 'self' ws://localhost:5173 http://localhost:3001 http://localhost:5173 https:;
-      style-src 'self' 'unsafe-inline' http://localhost:5173 https:;
-    ">
-  <link rel="preconnect" href="https://api.fontshare.com">
-  <link href="https://api.fontshare.com/v2/css?f[]=general-sans@400,600,700&display=swap" rel="stylesheet">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;600&display=swap" rel="stylesheet">
     <title>Local Effort</title>
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "Organization",
-        "name": "Local Effort",
-        "url": "https://localeffortfood.com/",
-        "logo": "https://localeffortfood.com/gallery/logo.png",
-        "sameAs": []
-      }
-    </script>
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "WebSite",
-        "name": "Local Effort",
-        "url": "https://localeffortfood.com/",
-        "potentialAction": {
-          "@type": "SearchAction",
-          "target": "https://localeffortfood.com/api/support/search?q={search_term_string}",
-          "query-input": "required name=search_term_string"
-        }
-      }
-    </script>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-P0Q3W8KEKY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-P0Q3W8KEKY');
-</script>
-    <script type="module" crossorigin src="/assets/index-BWxEXPpg.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Bcbs4zuk.css">
-  <title data-rh="true"></title>
-</head>
+    <meta http-equiv="refresh" content="0;url=/services" />
+    <link rel="canonical" href="/services" />
+  </head>
   <body>
-  <!-- Optional runtime Sanity config (generated at deploy-time) -->
-  <script src="/runtime-sanity-config.js"></script>
-  <div id="root"><div class="app-root min-h-screen flex flex-col"><header class="sticky top-0 z-40 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60"><div class="mx-auto max-w-6xl px-2 md:px-5 lg:px-6 h-14 flex items-center justify-between"><a class="flex items-center gap-2" href="/"><img src="/gallery/logo.png?text=Local+Effort&amp;font=mono" alt="Local Effort Logo" class="h-7 w-auto"/></a><nav class="hidden md:flex items-center gap-2 font-mono text-[0.9rem]"><div class="relative group"><a class="relative px-2 py-1 rounded" href="/services"><span class="transition-colors hover:text-neutral-900 text-neutral-700">Services</span><span class="absolute left-2 right-2 -bottom-0.5 h-0.5 bg-[var(--color-accent)]" style="opacity:0"></span></a><div class="absolute left-0 mt-1"><div class="invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-opacity"><div class="mt-1 rounded-md border bg-white shadow-lg py-1 min-w-[220px]"><a class="block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-50" href="/services#event-request">Submit an event request</a></div></div></div></div><div class="relative group"><a class="relative px-2 py-1 rounded" href="/pricing"><span class="transition-colors hover:text-neutral-900 text-neutral-700">Pricing</span><span class="absolute left-2 right-2 -bottom-0.5 h-0.5 bg-[var(--color-accent)]" style="opacity:0"></span></a></div><div class="relative group"><a class="relative px-2 py-1 rounded" href="/menu"><span class="transition-colors hover:text-neutral-900 text-neutral-700">Menus</span><span class="absolute left-2 right-2 -bottom-0.5 h-0.5 bg-[var(--color-accent)]" style="opacity:0"></span></a></div><div class="relative group"><a class="relative px-2 py-1 rounded" href="/pizza-party"><span class="transition-colors hover:text-neutral-900 text-neutral-700">Pizza Party</span><span class="absolute left-2 right-2 -bottom-0.5 h-0.5 bg-[var(--color-accent)]" style="opacity:0"></span></a></div><div class="relative group"><a aria-current="page" class="relative px-2 py-1 rounded active" href="/food-truck"><span class="transition-colors hover:text-neutral-900 text-neutral-700">Book a Food Truck</span><span class="absolute left-2 right-2 -bottom-0.5 h-0.5 bg-[var(--color-accent)]" style="opacity:1"></span></a></div><div class="relative group"><a class="relative px-2 py-1 rounded" href="/about"><span class="transition-colors hover:text-neutral-900 text-neutral-700">About</span><span class="absolute left-2 right-2 -bottom-0.5 h-0.5 bg-[var(--color-accent)]" style="opacity:0"></span></a></div><div class="relative group"><a class="relative px-2 py-1 rounded" href="/gallery"><span class="transition-colors hover:text-neutral-900 text-neutral-700">Gallery</span><span class="absolute left-2 right-2 -bottom-0.5 h-0.5 bg-[var(--color-accent)]" style="opacity:0"></span></a></div></nav><button class="md:hidden z-50 w-9 h-7 flex flex-col justify-between" aria-label="Toggle menu"><span class="block h-0.5 w-full bg-black transition-transform "></span><span class="block h-0.5 w-full bg-black transition-opacity opacity-100"></span><span class="block h-0.5 w-full bg-black transition-transform "></span></button></div></header><main class="flex-1"></main><footer class="mt-16 border-t border-neutral-200"><div class="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-8 font-mono text-sm text-neutral-700"><div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4"><div><p>© <!-- -->2025<!-- --> Local Effort</p><p class="text-neutral-500">Roseville, MN · Midwest</p><p class="mt-2 text-neutral-600">Service Areas:<!-- --> <a href="/personal-chef-minneapolis" class="underline underline-offset-4 hover:opacity-80">Minneapolis</a> <!-- -->|<!-- --> <a href="/personal-chef-st-paul" class="underline underline-offset-4 hover:opacity-80">St. Paul</a> <!-- -->|<!-- --> <a href="/personal-chef-twin-cities" class="underline underline-offset-4 hover:opacity-80">Twin Cities</a> <!-- -->|<!-- --> <a href="/personal-chef-minnesota" class="underline underline-offset-4 hover:opacity-80">Minnesota</a> <!-- -->|<!-- --> <a href="/personal-chef-wisconsin" class="underline underline-offset-4 hover:opacity-80">Wisconsin</a></p></div><div class="flex gap-4"><a href="https://www.tiktok.com/@localeffort" class="underline underline-offset-4 hover:opacity-80">TikTok (@localeffort)</a><a href="https://instagram.com/localeffort" class="underline underline-offset-4 hover:opacity-80">Instagram</a><a href="https://facebook.com/localeffort" class="underline underline-offset-4 hover:opacity-80">Facebook</a><a href="https://www.thumbtack.com/mn/saint-paul/personal-chefs/weston-smith/service/429294230165643268" class="underline underline-offset-4 hover:opacity-80">Thumbtack</a></div></div></div></footer></div></div>
-  <noscript>This site works best with JavaScript enabled. Key content is still visible above.</noscript>
-
+    <p>If you are not redirected automatically, please visit <a href="/services">our services page</a>.</p>
   </body>
 </html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,7 +6,6 @@
   <url><loc>https://localeffortfood.com/pricing</loc></url>
   <url><loc>https://localeffortfood.com/menu</loc></url>
   <url><loc>https://localeffortfood.com/happy-monday</loc></url>
-  <url><loc>https://localeffortfood.com/food-truck</loc></url>
   <url><loc>https://localeffortfood.com/gallery</loc></url>
   <url><loc>https://localeffortfood.com/meal-prep</loc></url>
   <url><loc>https://localeffortfood.com/partner-portal</loc></url>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,7 +53,6 @@ const PersonalChefTwinCitiesPage = lazy(() => import('./pages/PersonalChefTwinCi
 const PersonalChefMinnesotaPage = lazy(() => import('./pages/PersonalChefMinnesota'));
 const PersonalChefWisconsinPage = lazy(() => import('./pages/PersonalChefWisconsin'));
 const PizzaPartyPage = lazy(() => import('./pages/PizzaPartyPage'));
-const FoodTruckPage = lazy(() => import('./pages/FoodTruckPage'));
 
 const AppContent = () => {
   const location = useLocation();
@@ -239,14 +238,6 @@ const AppContent = () => {
                   element={
                     <AnimatedPage>
                       <PizzaPartyPage />
-                    </AnimatedPage>
-                  }
-                />
-                <Route
-                  path="/food-truck"
-                  element={
-                    <AnimatedPage>
-                      <FoodTruckPage />
                     </AnimatedPage>
                   }
                 />

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -10,7 +10,7 @@ const links = [
   { path: '/pricing', name: 'Pricing' },
   { path: '/menu', name: 'Menus' },
   { path: '/pizza-party', name: 'Pizza Party' },
-  { path: '/food-truck', name: 'Book a Food Truck' },
+  // { path: '/food-truck', name: 'Book a Food Truck' }, // temporarily hidden
   { path: '/about', name: 'About' },
   // { path: '/happy-monday', name: 'Happy Monday' }, // temporarily hidden
   { path: '/gallery', name: 'Gallery' },

--- a/tools/static-export.js
+++ b/tools/static-export.js
@@ -85,7 +85,6 @@ const routes = [
   '/pricing',
   '/menu',
   '/happy-monday',
-  '/food-truck',
   '/gallery',
   '/meal-prep',
   '/partner-portal',


### PR DESCRIPTION
## Summary
- remove the food truck route from the application router and navigation
- exclude the food truck path from static exports and the sitemap
- replace the prerendered food truck HTML with a redirect to the services page

## Testing
- npm install
- npm start -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68df14bdb75c8321b93df5fca63666cc