### PR TITLE
Ensure homepage hero image uses specified Cloudinary asset

### DIFF
--- a/src/components/common/cloudinaryImage.jsx
+++ b/src/components/common/cloudinaryImage.jsx
@@ -36,7 +36,7 @@ const cld = new Cloudinary({
  */
 import { useState, useEffect, useRef } from 'react';
 
-const CloudinaryImage = ({ publicId, alt, width, height, className, containerClassName, imgClassName, containerStyle, disableLazy = false, fallbackSrc, resizeMode = 'fill', placeholderMode = 'blur', sizes, responsiveSteps = [480, 768, 1024, 1400], eager = false }) => {
+const CloudinaryImage = ({ publicId, alt, width, height, className, containerClassName, imgClassName, containerStyle, disableLazy = false, fallbackSrc, resizeMode = 'fill', placeholderMode = 'blur', sizes, responsiveSteps = [480, 768, 1024, 1400], eager = false, version }) => {
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState(false);
   const imgRef = useRef(null);
@@ -53,11 +53,18 @@ const CloudinaryImage = ({ publicId, alt, width, height, className, containerCla
 
   // Use the public ID to get the image object from Cloudinary
   const myImage = cld.image(publicId);
+  if (version) {
+    myImage.setVersion(version);
+  }
 
   // Build a small blurred placeholder URL (low-res but not tiny so it looks better on slow networks)
   const phW = 80; // small preview width
   const phH = Math.max(20, Math.round((height || 80) * (phW / (width || 80))));
-  const placeholderImg = cld.image(publicId).resize(fill(phW, phH)).quality(20).format(formatAuto());
+  const placeholderImg = cld.image(publicId);
+  if (version) {
+    placeholderImg.setVersion(version);
+  }
+  placeholderImg.resize(fill(phW, phH)).quality(20).format(formatAuto());
   const placeholderUrl = placeholderImg.toURL();
 
   // Apply standard optimizations and transformations using the correctly imported functions
@@ -126,7 +133,7 @@ const CloudinaryImage = ({ publicId, alt, width, height, className, containerCla
       if (el && onLoad) el.removeEventListener('load', onLoad);
       if (el && onError) el.removeEventListener('error', onError);
     };
-  }, [publicId]);
+  }, [publicId, version]);
 
   if (error && fallbackSrc) {
     return (

--- a/src/components/seo/DefaultSeo.jsx
+++ b/src/components/seo/DefaultSeo.jsx
@@ -10,12 +10,13 @@ import {
   SITE_URL,
   SOCIAL_LINKS,
 } from '../../config/siteMetadata';
-import { cloudinaryConfig, heroPublicId, heroFallbackSrc } from '../../data/cloudinaryContent';
+import { cloudinaryConfig, heroPublicId, heroFallbackSrc, heroVersion } from '../../data/cloudinaryContent';
 
 const buildOgImageUrl = () => {
   const cloudName = cloudinaryConfig?.cloudName;
   if (cloudName && heroPublicId) {
-    return `https://res.cloudinary.com/${cloudName}/image/upload/f_auto,q_auto,w_1200/${heroPublicId}.jpg`;
+    const versionSegment = heroVersion ? `/v${heroVersion}` : '';
+    return `https://res.cloudinary.com/${cloudName}/image/upload/f_auto,q_auto,w_1200${versionSegment}/${heroPublicId}.jpg`;
   }
   if (heroFallbackSrc) {
     return `${SITE_URL}${heroFallbackSrc}`;

--- a/src/data/cloudinaryContent.js
+++ b/src/data/cloudinaryContent.js
@@ -5,8 +5,9 @@ export const cloudinaryConfig = {
   cloudName: (typeof import.meta !== 'undefined' && import.meta.env?.VITE_CLOUDINARY_CLOUD_NAME) || 'dokyhfvyd',
 };
 
-// Home hero image public_id
+// Home hero image metadata
 export const heroPublicId = 'vjuesai2mxfavpq9d2df'; // Cloudinary hero image public_id
+export const heroVersion = '1759456148'; // Explicit version to ensure the latest upload is shown
 export const heroFallbackSrc = '/gallery/IMG_3145.jpg'; // local fallback image
 
 // Partner logo public_ids (add/remove as needed)

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -6,7 +6,7 @@ import { motion } from 'framer-motion';
 import { fadeInUp, fadeInLeft } from '../utils/animations';
 import CloudinaryImage from '../components/common/cloudinaryImage'; // Import the Cloudinary image component
 import { useEffect } from 'react';
-import { cloudinaryConfig, heroPublicId, heroFallbackSrc } from '../data/cloudinaryContent';
+import { cloudinaryConfig, heroPublicId, heroFallbackSrc, heroVersion } from '../data/cloudinaryContent';
 import TestimonialsCarousel from '../components/common/TestimonialsCarousel';
 import sanityClient from '../sanityClient';
 import { PortableText } from '@portabletext/react';
@@ -155,13 +155,18 @@ const HomePage = () => {
   };
 
   // --- NEW: Define image data for both the component and structured data ---
-  const heroImage = { publicId: heroPublicId, alt: 'Local Effort — hero' };
+  const heroImage = {
+    publicId: heroPublicId,
+    alt: 'Local Effort — hero',
+    version: heroVersion,
+  };
+  const heroVersionSegment = heroImage.version ? `/v${heroImage.version}` : '';
 
   // --- NEW: Define the JSON-LD structured data object for SEO ---
   const imageJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'ImageObject',
-  contentUrl: `https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto/${heroImage.publicId}`,
+    contentUrl: `https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto${heroVersionSegment}/${heroImage.publicId}`,
     name: heroImage.alt,
     description: 'A sample of the professional in-home dining experience by Local Effort.',
     creator: {
@@ -435,8 +440,8 @@ const HomePage = () => {
         <link
           rel="preload"
           as="image"
-          href={`https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1200/${heroImage.publicId}`}
-          imageSrcSet={`https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_600/${heroImage.publicId} 600w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1200/${heroImage.publicId} 1200w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1800/${heroImage.publicId} 1800w`}
+          href={`https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1200${heroVersionSegment}/${heroImage.publicId}`}
+          imageSrcSet={`https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_600${heroVersionSegment}/${heroImage.publicId} 600w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1200${heroVersionSegment}/${heroImage.publicId} 1200w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1800${heroVersionSegment}/${heroImage.publicId} 1800w`}
           imageSizes="(min-width: 1024px) 50vw, 100vw"
         />
         {/* --- NEW: Inject the structured data into the page head --- */}
@@ -566,6 +571,7 @@ const HomePage = () => {
           >
             <CloudinaryImage
               publicId={heroImage.publicId}
+              version={heroImage.version}
               alt={heroImage.alt}
               width={1200}
               height={800}


### PR DESCRIPTION
## Summary
- add an explicit version for the Cloudinary hero asset so the homepage always renders the requested image
- update the homepage preload, schema data, and SEO tags to reference the versioned Cloudinary URL
- extend the reusable CloudinaryImage component to support versioned assets

## Testing
- npm run lint *(fails: ESLint 9 requires migrating to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68df2bb4b0688321b5d3d4c33711b626