### PR TITLE
Delay Square card initialization until crowdfunding form is visible

### DIFF
--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -368,7 +368,19 @@ const CrowdfundingPage = () => {
   const title = campaignTitle || 'Crowdfunding';
 
   // Initialize shared Square card (enabled only when a payable tier exists)
-  const { cardLoaded, error: squareConfigError, tokenize, envInfo } = useSquareCard('#cf-card-container', !!activeTier, [activeTier?.amount]);
+  const {
+    cardLoaded,
+    error: squareConfigError,
+    tokenize,
+    envInfo,
+    reset: resetSquareCard,
+  } = useSquareCard('#cf-card-container', showForm && !!activeTier, [showForm, activeTier?.amount]);
+
+  useEffect(() => {
+    if (!showForm) {
+      resetSquareCard();
+    }
+  }, [showForm, resetSquareCard]);
 
   // On return from Square (?payment=success), confirm and update counters
   useEffect(() => {


### PR DESCRIPTION
## Summary
- wait to initialize the Square Web Payments card until the crowdfunding checkout form is displayed
- reset the embedded Square card instance whenever the form is hidden to prevent stale references

## Testing
- npx eslint src/pages/CrowdfundingPage.jsx *(fails: ESLint 9 requires eslint.config.js in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68df320d6d3483218897d7c8f00e9b5c