### PR TITLE
Add beta badge to food truck navigation link

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -10,7 +10,7 @@ const links = [
   { path: '/pricing', name: 'Pricing' },
   { path: '/menu', name: 'Menus' },
   { path: '/pizza-party', name: 'Pizza Party' },
-  { path: '/book-food-truck', name: 'Book a Food Truck' },
+  { path: '/book-food-truck', name: 'Book a Food Truck', tag: 'Beta' },
   { path: '/about', name: 'About' },
   // { path: '/happy-monday', name: 'Happy Monday' }, // temporarily hidden
   { path: '/gallery', name: 'Gallery' },
@@ -47,45 +47,50 @@ export const Header = () => {
 
         {/* Desktop nav */}
         <nav className="hidden md:flex items-center gap-2 font-mono text-[0.9rem]">
-          {links.map(({ path, name, sale, children }) => (
+          {links.map(({ path, name, sale, children, tag }) => (
             <div key={path} className="relative group">
-            <NavLink to={path} className="relative px-2 py-1 rounded">
-              {({ isActive }) => (
-                <>
-                  {sale ? (
-                    <span className={`inline-flex items-center rounded-md px-2 py-1 text-white shadow-sm transition-transform ${isActive ? 'scale-[1.02]' : ''}`} style={{ backgroundColor: '#e11d48' }}>
-                      {name}
-                    </span>
-                  ) : (
-                    <span className="transition-colors hover:text-neutral-900 text-neutral-700">
-                      {name}
-                    </span>
-                  )}
-                  {!sale && (
-                    <motion.span
-                      layoutId="nav-underline"
-                      className="absolute left-2 right-2 -bottom-0.5 h-0.5 bg-[var(--color-accent)]"
-                      initial={false}
-                      animate={{ opacity: isActive ? 1 : 0 }}
-                      transition={{ duration: 0.2 }}
-                    />
-                  )}
-                </>
-              )}
-            </NavLink>
-            {children && (
-              <div className="absolute left-0 mt-1">
-                <div className="invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-opacity">
-                  <div className="mt-1 rounded-md border bg-white shadow-lg py-1 min-w-[220px]">
-                    {children.map((c) => (
-                      <NavLink key={c.path} to={c.path} className="block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-50">
-                        {c.name}
-                      </NavLink>
-                    ))}
+              <NavLink to={path} className="relative px-2 py-1 rounded">
+                {({ isActive }) => (
+                  <>
+                    {sale ? (
+                      <span className={`inline-flex items-center rounded-md px-2 py-1 text-white shadow-sm transition-transform ${isActive ? 'scale-[1.02]' : ''}`} style={{ backgroundColor: '#e11d48' }}>
+                        {name}
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 transition-colors hover:text-neutral-900 text-neutral-700">
+                        <span>{name}</span>
+                        {tag && (
+                          <span className="inline-flex items-center rounded-full bg-rose-100 px-2 py-0.5 text-[0.55rem] font-semibold uppercase tracking-[0.2em] text-rose-500">
+                            {tag}
+                          </span>
+                        )}
+                      </span>
+                    )}
+                    {!sale && (
+                      <motion.span
+                        layoutId="nav-underline"
+                        className="absolute left-2 right-2 -bottom-0.5 h-0.5 bg-[var(--color-accent)]"
+                        initial={false}
+                        animate={{ opacity: isActive ? 1 : 0 }}
+                        transition={{ duration: 0.2 }}
+                      />
+                    )}
+                  </>
+                )}
+              </NavLink>
+              {children && (
+                <div className="absolute left-0 mt-1">
+                  <div className="invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-opacity">
+                    <div className="mt-1 rounded-md border bg-white shadow-lg py-1 min-w-[220px]">
+                      {children.map((c) => (
+                        <NavLink key={c.path} to={c.path} className="block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-50">
+                          {c.name}
+                        </NavLink>
+                      ))}
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
             </div>
           ))}
           {SHOW_FUNDRAISER && (
@@ -141,7 +146,7 @@ export const Header = () => {
               }}
               className="flex flex-col items-center justify-center h-full space-y-6 font-mono px-6"
             >
-      {links.map((l) => (
+              {links.map((l) => (
                 <motion.div
                   key={l.path}
                   variants={{ hidden: { y: 10, opacity: 0 }, show: { y: 0, opacity: 1 } }}
@@ -152,7 +157,14 @@ export const Header = () => {
                       onClick={() => setIsOpen(false)}
                       className={`block text-3xl uppercase text-center ${l.sale ? 'bg-rose-600 text-white px-4 py-2 rounded-md' : ''}`}
                     >
-                      {l.name}
+                      <span className="flex items-center justify-center gap-2">
+                        <span>{l.name}</span>
+                        {l.tag && (
+                          <span className="inline-flex items-center rounded-full bg-rose-100 px-2 py-0.5 text-xs font-semibold uppercase tracking-[0.2em] text-rose-500">
+                            {l.tag}
+                          </span>
+                        )}
+                      </span>
                     </NavLink>
                   ) : (
                     <div className="w-full max-w-md">


### PR DESCRIPTION
## Summary
- add a `Beta` tag to the "Book a Food Truck" navigation entry so it displays in the site header
- show the same badge when the item is rendered in the mobile navigation menu

## Testing
- `npm run start -- --host 0.0.0.0 --port 4173` *(fails: existing JSX markup mismatch errors in src/pages/FoodTruckPage.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68df36acdbb08321a89fe1f8f9fc1d62