### PR TITLE
Remove fixed hero dimensions for Cloudinary hero image

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -573,8 +573,6 @@ const HomePage = () => {
               publicId={heroImage.publicId}
               version={heroImage.version}
               alt={heroImage.alt}
-              width={1200}
-              height={800}
               containerClassName="w-full h-full"
               imgClassName="w-full h-full object-cover object-center"
               fallbackSrc={heroFallbackSrc}


### PR DESCRIPTION
## Summary
- remove the hard-coded width and height passed to the homepage hero CloudinaryImage so Cloudinary can serve responsive renditions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff9fe7f5c83218aa6951b2cb1a981