### PR TITLE
Handle missing crowdfunding tiers and restore pizza party dates

### DIFF
--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -147,6 +147,7 @@ const CrowdfundingPage = () => {
   const [showForm, setShowForm] = useState(false);
   const [pizzaQty, setPizzaQty] = useState(1);
   const [confirmMsg, setConfirmMsg] = useState('');
+  const [formNotice, setFormNotice] = useState('');
   const [referralInput, setReferralInput] = useState('');
   const [referralState, setReferralState] = useState({ status: 'idle', valid: false, participant: null, code: '' });
   const [selectedTierId, setSelectedTierId] = useState('');
@@ -289,6 +290,10 @@ const CrowdfundingPage = () => {
       return true;
     });
   }, [rewardTiers, referralState]);
+  const hasPayableTier = useMemo(
+    () => visibleTiers.some((t) => typeof t?.amount === 'number' && t.amount > 0),
+    [visibleTiers]
+  );
   const firstPayTier = useMemo(
     () => visibleTiers.find(t => typeof t?.amount === 'number' && t.amount > 0) || null,
     [visibleTiers]
@@ -299,6 +304,23 @@ const CrowdfundingPage = () => {
     const exists = visibleTiers.some((tier) => tierIdentifier(tier) === selectedTierId);
     if (!exists) setSelectedTierId('');
   }, [selectedTierId, visibleTiers]);
+
+  useEffect(() => {
+    if (showForm && !activeTier) {
+      setShowForm(false);
+      setFormNotice(
+        hasPayableTier
+          ? 'That reward is no longer available. Please pick another tier to continue.'
+          : 'Online checkout is temporarily unavailable. Email hello@localeffortfood.com to pledge.'
+      );
+    }
+  }, [showForm, activeTier, hasPayableTier]);
+
+  useEffect(() => {
+    if (!showForm && hasPayableTier && activeTier) {
+      setFormNotice('');
+    }
+  }, [showForm, hasPayableTier, activeTier]);
 
   const activeTier = useMemo(() => {
     if (selectedTierId) {
@@ -315,7 +337,12 @@ const CrowdfundingPage = () => {
   }, [activeTier]);
 
   const handleTierSelect = (tier) => {
+    if (!tier || typeof tier.amount !== 'number' || tier.amount <= 0) {
+      setFormNotice('Online checkout is only available for paid rewards. Please choose another tier.');
+      return;
+    }
     setSelectedTierId(tierIdentifier(tier));
+    setFormNotice('');
     setShowForm(true);
   };
 
@@ -697,13 +724,27 @@ const CrowdfundingPage = () => {
               {!showForm && (
                 <Button
                   type="button"
-                  onClick={() => setShowForm(true)}
+                  onClick={() => {
+                    if (!activeTier) {
+                      setFormNotice('Reward tiers are loading. Please try again in a moment.');
+                      return;
+                    }
+                    setSelectedTierId(tierIdentifier(activeTier));
+                    setFormNotice('');
+                    setShowForm(true);
+                  }}
                   className="w-full text-lg h-12"
+                  disabled={!hasPayableTier}
                 >
                   I want pizza
                 </Button>
               )}
-              {showForm && (
+              {(formNotice || (!hasPayableTier && !showForm)) && (
+                <p className="text-sm text-slate-600">
+                  {formNotice || 'Online checkout is temporarily unavailable. Email hello@localeffortfood.com to pledge.'}
+                </p>
+              )}
+              {showForm && activeTier && (
                 <form
                   className="space-y-6"
                   onSubmit={(event) => {

--- a/src/pages/PizzaPartyPage.jsx
+++ b/src/pages/PizzaPartyPage.jsx
@@ -46,6 +46,23 @@ const formatDateLabel = (isoDate, fallbackLabel) => {
   return `${MONTH_NAMES[dateObj.getMonth()]} ${dateObj.getDate()}`;
 };
 
+const getNextScheduledDate = (isoDate, today) => {
+  const baseDate = toLocalDate(isoDate);
+  if (!baseDate) return null;
+  const anchor = new Date(today);
+  anchor.setHours(0, 0, 0, 0);
+  let candidate = new Date(baseDate);
+  let safety = 0;
+  while (candidate < anchor && safety < 10) {
+    candidate.setFullYear(candidate.getFullYear() + 1);
+    safety += 1;
+  }
+  if (candidate < anchor) {
+    return null;
+  }
+  return candidate;
+};
+
 // NOTE: Replaced custom embedded payment logic with shared useSquareCard hook.
 
 const PizzaPartyPage = () => {
@@ -64,15 +81,19 @@ const PizzaPartyPage = () => {
 
   const upcomingDates = PIZZA_PARTY_DATES
     .map((entry) => {
-      const dateObj = toLocalDate(entry.isoDate);
+      const nextDate = getNextScheduledDate(entry.isoDate, startOfToday);
+      if (!nextDate) return null;
+      const isoDate = nextDate.toISOString().slice(0, 10);
+      const label = entry.label || formatDateLabel(isoDate, entry.label);
       return {
         ...entry,
-        label: entry.label || formatDateLabel(entry.isoDate, entry.label),
-        dateObj,
-        weekday: dateObj ? dateObj.toLocaleDateString('en-US', { weekday: 'short' }) : ''
+        label,
+        isoDate,
+        dateObj: nextDate,
+        weekday: nextDate.toLocaleDateString('en-US', { weekday: 'short' })
       };
     })
-    .filter((entry) => entry.dateObj && entry.dateObj >= startOfToday)
+    .filter(Boolean)
     .sort((a, b) => (a.dateObj && b.dateObj ? a.dateObj - b.dateObj : 0));
 
   const availabilityYears = Array.from(new Set(upcomingDates.map((entry) => entry.dateObj?.getFullYear()).filter(Boolean)));


### PR DESCRIPTION
## Summary
- guard the crowdfunding purchase flow when no paid reward tiers are available so the "I want pizza" CTA no longer blows up and shows a friendly notice instead
- roll the pizza party schedule forward from the stored month/day values so the booking calendar and JSON-LD keep showing upcoming dates

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dff985bf4c8321acc3ff2e072f044c