### PR TITLE
Fix Square card cleanup timing

### DIFF
--- a/src/hooks/useSquareCard.js
+++ b/src/hooks/useSquareCard.js
@@ -188,19 +188,32 @@ export function useSquareCard(containerId, enabled, deps = []) {
 
   const destroyCardInstance = useCallback(() => {
     const card = cardRef.current;
-    if (!card) return;
     cardRef.current = null;
     attachStartedRef.current = false;
+
+    const finalize = () => {
+      cleanupContainer();
+      setCardLoaded(false);
+    };
+
+    if (!card) {
+      finalize();
+      return;
+    }
+
     try {
       const maybePromise = typeof card.destroy === 'function' ? card.destroy() : undefined;
       if (maybePromise && typeof maybePromise.then === 'function') {
-        maybePromise.catch(() => {});
+        maybePromise
+          .catch(() => {})
+          .finally(finalize);
+        return;
       }
     } catch (_) {
       // ignore destroy issues
     }
-    cleanupContainer();
-    setCardLoaded(false);
+
+    finalize();
   }, [cleanupContainer]);
 
   // Allow consumer to manually force a remount (e.g., when reopening a modal)


### PR DESCRIPTION
## Summary
- avoid clearing the Square card container before the SDK finishes tearing down the iframe
- ensure the cleanup still runs when no card instance is present

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e00bfb99d08321b6b6bf07adaa27e7