### PR TITLE
Increase hero hero image resolution breakpoints

### DIFF
--- a/src/components/common/cloudinaryImage.jsx
+++ b/src/components/common/cloudinaryImage.jsx
@@ -36,7 +36,7 @@ const cld = new Cloudinary({
  */
 import { useState, useEffect, useRef } from 'react';
 
-const CloudinaryImage = ({ publicId, alt, width, height, className, containerClassName, imgClassName, containerStyle, disableLazy = false, fallbackSrc, resizeMode = 'fill', placeholderMode = 'blur', sizes, responsiveSteps = [480, 768, 1024, 1400], eager = false, version }) => {
+const CloudinaryImage = ({ publicId, alt, width, height, className, containerClassName, imgClassName, containerStyle, disableLazy = false, fallbackSrc, resizeMode = 'fill', placeholderMode = 'blur', sizes, responsiveSteps = [480, 768, 1024, 1400, 2000, 2600, 3200], eager = false, version }) => {
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState(false);
   const imgRef = useRef(null);

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -440,9 +440,9 @@ const HomePage = () => {
         <link
           rel="preload"
           as="image"
-          href={`https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1200${heroVersionSegment}/${heroImage.publicId}`}
-          imageSrcSet={`https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_600${heroVersionSegment}/${heroImage.publicId} 600w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1200${heroVersionSegment}/${heroImage.publicId} 1200w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1800${heroVersionSegment}/${heroImage.publicId} 1800w`}
-          imageSizes="(min-width: 1024px) 50vw, 100vw"
+          href={`https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_2400${heroVersionSegment}/${heroImage.publicId}`}
+          imageSrcSet={`https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_800${heroVersionSegment}/${heroImage.publicId} 800w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1200${heroVersionSegment}/${heroImage.publicId} 1200w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_1800${heroVersionSegment}/${heroImage.publicId} 1800w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_2400${heroVersionSegment}/${heroImage.publicId} 2400w, https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/f_auto,q_auto,w_3200${heroVersionSegment}/${heroImage.publicId} 3200w`}
+          imageSizes="(min-width: 1536px) 768px, (min-width: 1280px) 688px, (min-width: 1024px) 50vw, 100vw"
         />
         {/* --- NEW: Inject the structured data into the page head --- */}
         <script type="application/ld+json">{JSON.stringify(imageJsonLd)}</script>
@@ -573,12 +573,11 @@ const HomePage = () => {
               publicId={heroImage.publicId}
               version={heroImage.version}
               alt={heroImage.alt}
-              width={1200}
-              height={800}
               containerClassName="w-full h-full"
               imgClassName="w-full h-full object-cover object-center"
               fallbackSrc={heroFallbackSrc}
-              sizes="(min-width: 1024px) 50vw, 100vw"
+              sizes="(min-width: 1536px) 768px, (min-width: 1280px) 688px, (min-width: 1024px) 50vw, 100vw"
+              responsiveSteps={[600, 900, 1200, 1600, 2000, 2600, 3200]}
               eager
             />
           </motion.div>


### PR DESCRIPTION
## Summary
- expand the default Cloudinary responsive breakpoints so high-DPI screens can fetch wider renditions
- update the homepage hero preload and image sizing metadata to request 2400–3200px versions instead of topping out at 1200px

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff9fe7f5c83218aa6951b2cb1a981