### PR TITLE
Fix pizza party booking modal reset and drop expired dates

### DIFF
--- a/src/pages/PizzaPartyPage.jsx
+++ b/src/pages/PizzaPartyPage.jsx
@@ -49,17 +49,17 @@ const formatDateLabel = (isoDate, fallbackLabel) => {
 const getNextScheduledDate = (isoDate, today) => {
   const baseDate = toLocalDate(isoDate);
   if (!baseDate) return null;
+
+  const candidate = new Date(baseDate);
+  candidate.setHours(0, 0, 0, 0);
+
   const anchor = new Date(today);
   anchor.setHours(0, 0, 0, 0);
-  let candidate = new Date(baseDate);
-  let safety = 0;
-  while (candidate < anchor && safety < 10) {
-    candidate.setFullYear(candidate.getFullYear() + 1);
-    safety += 1;
-  }
+
   if (candidate < anchor) {
     return null;
   }
+
   return candidate;
 };
 
@@ -284,7 +284,15 @@ const PizzaPartyPage = () => {
 
   const openModal = (date) => {
     // force a fresh mount each time modal opens
-    reset();
+    try {
+      if (typeof reset === 'function') {
+        reset();
+      }
+    } catch (err) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[pizza-party] failed to reset payment form', err);
+      }
+    }
     setShowModal(true);
     setSelectedDate(date);
   };


### PR DESCRIPTION
## Summary
- prevent pizza party availability from rolling past dates forward to future years so outdated slots fall off automatically
- wrap the Square card reset logic when opening the booking modal to avoid crashes if the payment form reset throws

## Testing
- npm run build
- npm run lint *(fails: pre-existing lint errors about unrelated unused variables and console statements)*

------
https://chatgpt.com/codex/tasks/task_e_68e1487c5e708321b25c31d74eb52fd6