### PR TITLE
Limit pizza party availability to 2025

### DIFF
--- a/src/pages/PizzaPartyPage.jsx
+++ b/src/pages/PizzaPartyPage.jsx
@@ -46,21 +46,17 @@ const formatDateLabel = (isoDate, fallbackLabel) => {
   return `${MONTH_NAMES[dateObj.getMonth()]} ${dateObj.getDate()}`;
 };
 
-const getNextScheduledDate = (isoDate, today) => {
+const DISPLAY_YEAR = 2025; // Limit the public schedule to the 2025 season.
+
+const projectDateToYear = (isoDate, targetYear) => {
   const baseDate = toLocalDate(isoDate);
   if (!baseDate) return null;
 
-  const candidate = new Date(baseDate);
-  candidate.setHours(0, 0, 0, 0);
+  const projected = new Date(baseDate);
+  projected.setHours(0, 0, 0, 0);
+  projected.setFullYear(targetYear);
 
-  const anchor = new Date(today);
-  anchor.setHours(0, 0, 0, 0);
-
-  if (candidate < anchor) {
-    return null;
-  }
-
-  return candidate;
+  return projected;
 };
 
 // NOTE: Replaced custom embedded payment logic with shared useSquareCard hook.
@@ -81,16 +77,16 @@ const PizzaPartyPage = () => {
 
   const upcomingDates = PIZZA_PARTY_DATES
     .map((entry) => {
-      const nextDate = getNextScheduledDate(entry.isoDate, startOfToday);
-      if (!nextDate) return null;
-      const isoDate = nextDate.toISOString().slice(0, 10);
+      const projectedDate = projectDateToYear(entry.isoDate, DISPLAY_YEAR);
+      if (!projectedDate || projectedDate < startOfToday) return null;
+      const isoDate = projectedDate.toISOString().slice(0, 10);
       const label = entry.label || formatDateLabel(isoDate, entry.label);
       return {
         ...entry,
         label,
         isoDate,
-        dateObj: nextDate,
-        weekday: nextDate.toLocaleDateString('en-US', { weekday: 'short' })
+        dateObj: projectedDate,
+        weekday: projectedDate.toLocaleDateString('en-US', { weekday: 'short' })
       };
     })
     .filter(Boolean)


### PR DESCRIPTION
## Summary
- limit the pizza party availability list to 2025 by projecting the configured dates into that season

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e15f2b77d48321be81e07fe600fba8