### PR TITLE
feat(api): integrate billing payments and batch jobs

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -6,11 +6,14 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "start": "node dist/main.js",
-    "dev": "ts-node --swc src/main.ts"
+    "dev": "ts-node --swc src/main.ts",
+    "test": "node --test -r ./test/setup-ts-node.cjs \"src/**/*.spec.ts\""
   },
   "dependencies": {
+    "@local-office/billing": "workspace:^",
     "@local-office/db": "workspace:^",
     "@local-office/lib": "workspace:^",
+    "@local-office/worker": "workspace:^",
     "@nestjs/common": "10.3.9",
     "@nestjs/config": "3.2.2",
     "@nestjs/core": "10.3.9",

--- a/services/api/src/modules/batch-lock.producer.ts
+++ b/services/api/src/modules/batch-lock.producer.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { enqueueBatchLock } from '@local-office/worker';
+import { createIdempotencyKey } from '@local-office/lib';
+
+type EnqueueOptions = Parameters<typeof enqueueBatchLock>[1];
+
+@Injectable()
+export class BatchLockProducer {
+  async enqueueLock(data: Record<string, unknown>, opts?: EnqueueOptions) {
+    const payload = {
+      ...data,
+      idempotencyKey:
+        (data['idempotencyKey'] as string | undefined) ??
+        createIdempotencyKey('batch-lock')
+    };
+
+    return enqueueBatchLock(payload, opts);
+  }
+}

--- a/services/api/src/modules/billing.provider.ts
+++ b/services/api/src/modules/billing.provider.ts
@@ -1,0 +1,7 @@
+import { Provider } from '@nestjs/common';
+import { BillingService } from '@local-office/billing';
+
+export const billingProvider: Provider = {
+  provide: BillingService,
+  useFactory: () => new BillingService()
+};

--- a/services/api/src/modules/orders/orders.module.ts
+++ b/services/api/src/modules/orders/orders.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 
+import { billingProvider } from '../billing.provider';
+import { BatchLockProducer } from '../batch-lock.producer';
 import { OrdersController } from './orders.controller';
 import { OrdersService } from './orders.service';
 
 @Module({
   controllers: [OrdersController],
-  providers: [OrdersService]
+  providers: [OrdersService, billingProvider, BatchLockProducer]
 })
 export class OrdersModule {}

--- a/services/api/src/modules/orders/orders.service.spec.ts
+++ b/services/api/src/modules/orders/orders.service.spec.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it, mock } from 'node:test';
+import { OrderStatus, PaymentMethod, Prisma } from '@local-office/db';
+
+import { OrdersService } from './orders.service';
+import { ConfirmOrderDto } from './dto/confirm-order.dto';
+
+const cutoffAt = new Date('2099-01-01T12:00:00Z');
+
+describe('OrdersService.confirm', () => {
+  const baseOrder = {
+    id: 'order-1',
+    programSlotId: 'slot-1',
+    userId: 'user-1',
+    status: OrderStatus.PENDING,
+    subtotal: new Prisma.Decimal(25),
+    tip: new Prisma.Decimal(0),
+    loyaltyDiscount: new Prisma.Decimal(0),
+    referralCredit: new Prisma.Decimal(0),
+    paymentFee: new Prisma.Decimal(0),
+    total: new Prisma.Decimal(25),
+    idempotencyKey: 'order-1',
+    items: [],
+    programSlot: {
+      id: 'slot-1',
+      cutoffAt
+    },
+    payment: null
+  } as const;
+
+  let prisma: any;
+  let billing: any;
+  let batchLockProducer: any;
+  let service: OrdersService;
+
+  beforeEach(() => {
+    prisma = {
+      order: {
+        findUnique: mock.fn(),
+        update: mock.fn()
+      },
+      payment: {
+        create: mock.fn()
+      }
+    };
+
+    billing = {
+      createPayment: mock.fn()
+    };
+
+    batchLockProducer = {
+      enqueueLock: mock.fn()
+    };
+
+    service = new OrdersService(prisma, billing, batchLockProducer);
+  });
+
+  it('creates a Square payment, stores it, and schedules a batch lock', async () => {
+    const dto: ConfirmOrderDto = {
+      paymentMethod: 'CARD',
+      tipOverride: 5,
+      idempotencyKey: 'idem-123'
+    };
+
+    const updatedOrder = {
+      ...baseOrder,
+      status: OrderStatus.LOCKED,
+      tip: new Prisma.Decimal(5),
+      total: new Prisma.Decimal(30),
+      items: []
+    };
+
+    const paymentResult = {
+      id: 'square-payment-1',
+      status: 'APPROVED',
+      amount: 30,
+      currency: 'USD'
+    };
+
+    const paymentRecord = {
+      id: 'payment-1',
+      orderId: baseOrder.id,
+      squarePaymentId: paymentResult.id,
+      method: PaymentMethod.CARD,
+      amount: new Prisma.Decimal(30),
+      feeAmount: baseOrder.paymentFee,
+      status: paymentResult.status,
+      receivedAt: new Date('2024-01-01T12:05:00Z')
+    };
+
+    prisma.order.findUnique.mock.mockImplementation(async () => baseOrder);
+    prisma.order.update.mock.mockImplementation(async () => updatedOrder);
+    billing.createPayment.mock.mockImplementation(async () => paymentResult);
+    prisma.payment.create.mock.mockImplementation(async () => paymentRecord);
+    batchLockProducer.enqueueLock.mock.mockImplementation(async () => undefined);
+
+    const result = await service.confirm(baseOrder.id, dto);
+
+    assert.equal(billing.createPayment.mock.callCount(), 1);
+    assert.deepEqual(billing.createPayment.mock.calls[0].arguments[0], {
+      amount: 30,
+      currency: 'USD',
+      customerId: baseOrder.userId,
+      sourceId: `square_${baseOrder.id}`,
+      idempotencyKey: dto.idempotencyKey
+    });
+
+    assert.equal(prisma.payment.create.mock.callCount(), 1);
+    const paymentArgs = prisma.payment.create.mock.calls[0].arguments[0];
+    assert.equal(paymentArgs.data.orderId, baseOrder.id);
+    assert.equal(paymentArgs.data.squarePaymentId, paymentResult.id);
+    assert.equal(paymentArgs.data.method, PaymentMethod.CARD);
+    assert.equal(paymentArgs.data.amount.toString(), new Prisma.Decimal(30).toString());
+    assert.equal(paymentArgs.data.feeAmount.toString(), baseOrder.paymentFee.toString());
+    assert.equal(paymentArgs.data.status, paymentResult.status);
+    assert.ok(paymentArgs.data.receivedAt instanceof Date);
+
+    assert.equal(batchLockProducer.enqueueLock.mock.callCount(), 1);
+    assert.deepEqual(batchLockProducer.enqueueLock.mock.calls[0].arguments[0], {
+      orderId: baseOrder.id,
+      programSlotId: baseOrder.programSlotId,
+      cutoffAt: baseOrder.programSlot.cutoffAt.toISOString(),
+      idempotencyKey: dto.idempotencyKey
+    });
+
+    assert.deepEqual(result.payment, paymentRecord);
+    assert.equal(result.order.status, OrderStatus.LOCKED);
+    assert.deepEqual(result.order.payment, paymentRecord);
+    assert.deepEqual(result.order.programSlot, baseOrder.programSlot);
+  });
+
+  it('returns existing payment when the order is already confirmed', async () => {
+    const lockedOrder = {
+      ...baseOrder,
+      status: OrderStatus.LOCKED,
+      payment: {
+        id: 'payment-existing',
+        squarePaymentId: 'square-existing',
+        method: PaymentMethod.ACH
+      }
+    };
+
+    prisma.order.findUnique.mock.mockImplementation(async () => lockedOrder);
+
+    const result = await service.confirm(baseOrder.id, {});
+
+    assert.equal(billing.createPayment.mock.callCount(), 0);
+    assert.equal(prisma.order.update.mock.callCount(), 0);
+    assert.equal(batchLockProducer.enqueueLock.mock.callCount(), 0);
+    assert.deepEqual(result.order, lockedOrder);
+    assert.deepEqual(result.payment, lockedOrder.payment);
+  });
+});

--- a/services/api/src/modules/orders/orders.service.ts
+++ b/services/api/src/modules/orders/orders.service.ts
@@ -3,16 +3,22 @@ import {
   Injectable,
   NotFoundException
 } from '@nestjs/common';
-import { OrderStatus, Prisma } from '@local-office/db';
+import { OrderStatus, PaymentMethod, Prisma } from '@local-office/db';
 import { assertBeforeCutoff, calculateOrderTotals, sumLineItems, toDecimal } from '@local-office/lib';
 
+import { BillingService } from '@local-office/billing';
 import { PrismaService } from '../prisma/prisma.service';
+import { BatchLockProducer } from '../batch-lock.producer';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { ConfirmOrderDto } from './dto/confirm-order.dto';
 
 @Injectable()
 export class OrdersService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly billing: BillingService,
+    private readonly batchLockProducer: BatchLockProducer
+  ) {}
 
   async create(dto: CreateOrderDto) {
     const totalQuantity = dto.items.reduce((acc, item) => acc + (item.quantity ?? 1), 0);
@@ -99,6 +105,7 @@ export class OrdersService {
     const order = await this.prisma.order.findUnique({
       where: { id },
       include: {
+        items: true,
         programSlot: true,
         payment: true
       }
@@ -109,7 +116,10 @@ export class OrdersService {
     }
 
     if (order.status !== OrderStatus.PENDING) {
-      return order;
+      return {
+        order,
+        payment: order.payment ?? undefined
+      };
     }
 
     assertBeforeCutoff(order.programSlot.cutoffAt);
@@ -129,10 +139,42 @@ export class OrdersService {
       }
     });
 
+    const paymentResult = await this.billing.createPayment({
+      amount: Number(total.total.toString()),
+      currency: 'USD',
+      customerId: order.userId,
+      sourceId: dto.paymentIntentId ?? `square_${id}`,
+      idempotencyKey: dto.idempotencyKey ?? `order_${id}`
+    });
+
+    const paymentMethod = (dto.paymentMethod ?? PaymentMethod.ACH) as PaymentMethod;
+
+    const payment = await this.prisma.payment.create({
+      data: {
+        orderId: id,
+        squarePaymentId: paymentResult.id,
+        method: paymentMethod,
+        amount: toDecimal(paymentResult.amount ?? total.total),
+        feeAmount: order.paymentFee,
+        status: paymentResult.status,
+        receivedAt: paymentResult.status === 'APPROVED' ? new Date() : null
+      }
+    });
+
+    await this.batchLockProducer.enqueueLock({
+      orderId: order.id,
+      programSlotId: order.programSlotId,
+      cutoffAt: order.programSlot.cutoffAt.toISOString(),
+      idempotencyKey: dto.idempotencyKey
+    });
+
     return {
-      order: updated,
-      paymentIntentId: dto.paymentIntentId ?? `square_${id}`,
-      paymentMethod: dto.paymentMethod ?? 'ACH'
+      order: {
+        ...updated,
+        programSlot: order.programSlot,
+        payment
+      },
+      payment
     };
   }
 }

--- a/services/api/test/setup-ts-node.cjs
+++ b/services/api/test/setup-ts-node.cjs
@@ -1,0 +1,6 @@
+const path = require('path');
+
+process.env.TS_NODE_PROJECT = path.join(__dirname, '..', 'tsconfig.spec.json');
+process.env.TS_NODE_TRANSPILE_ONLY = 'true';
+require('ts-node/register');
+require('tsconfig-paths/register');

--- a/services/api/test/stubs/local-office-db.ts
+++ b/services/api/test/stubs/local-office-db.ts
@@ -1,0 +1,78 @@
+export enum OrderStatus {
+  PENDING = 'PENDING',
+  LOCKED = 'LOCKED',
+  BATCHED = 'BATCHED',
+  FULFILLED = 'FULFILLED',
+  CANCELED = 'CANCELED'
+}
+
+export enum PaymentMethod {
+  CARD = 'CARD',
+  ACH = 'ACH'
+}
+
+class DecimalBase {
+  protected readonly value: number;
+
+  constructor(input: DecimalBase | number | string) {
+    this.value = DecimalBase.normalize(input);
+  }
+
+  private static normalize(value: DecimalBase | number | string): number {
+    if (value instanceof DecimalBase) {
+      return value.value;
+    }
+    if (typeof value === 'string') {
+      return Number(value);
+    }
+    return value;
+  }
+
+  protected operate(
+    operator: (current: number, next: number) => number,
+    other: DecimalBase | number | string
+  ) {
+    const ctor = this.constructor as new (input: DecimalBase | number | string) => DecimalBase;
+    return new ctor(operator(this.value, DecimalBase.normalize(other)));
+  }
+
+  plus(other: DecimalBase | number | string) {
+    return this.operate((a, b) => a + b, other);
+  }
+
+  minus(other: DecimalBase | number | string) {
+    return this.operate((a, b) => a - b, other);
+  }
+
+  mul(other: DecimalBase | number | string) {
+    return this.operate((a, b) => a * b, other);
+  }
+
+  toNumber() {
+    return this.value;
+  }
+
+  toString() {
+    return this.value.toString();
+  }
+
+  valueOf() {
+    return this.value;
+  }
+
+  toJSON() {
+    return this.toString();
+  }
+}
+
+export namespace Prisma {
+  export class Decimal extends DecimalBase {}
+}
+
+export class PrismaClient {
+  order: any;
+  payment: any;
+  programSlot: any;
+  sku: any;
+  user: any;
+}

--- a/services/api/test/stubs/local-office-worker.ts
+++ b/services/api/test/stubs/local-office-worker.ts
@@ -1,0 +1,3 @@
+export async function enqueueBatchLock(data: Record<string, unknown>) {
+  return { data };
+}

--- a/services/api/test/stubs/nestjs-common.ts
+++ b/services/api/test/stubs/nestjs-common.ts
@@ -1,0 +1,7 @@
+export class HttpException extends Error {}
+export class BadRequestException extends HttpException {}
+export class NotFoundException extends HttpException {}
+
+export function Injectable(): ClassDecorator {
+  return () => undefined;
+}

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -10,6 +10,16 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": "./",
+    "paths": {
+      "@local-office/db": ["../../packages/db/src"],
+      "@local-office/db/*": ["../../packages/db/src/*"],
+      "@local-office/lib": ["../../packages/lib/src"],
+      "@local-office/lib/*": ["../../packages/lib/src/*"],
+      "@local-office/billing": ["../billing/src"],
+      "@local-office/billing/*": ["../billing/src/*"],
+      "@local-office/worker": ["../worker/src"],
+      "@local-office/worker/*": ["../worker/src/*"]
+    },
     "incremental": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": false,

--- a/services/api/tsconfig.spec.json
+++ b/services/api/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@local-office/db": ["./test/stubs/local-office-db.ts"],
+      "@local-office/db/*": ["./test/stubs/local-office-db.ts"],
+      "@local-office/lib": ["../../packages/lib/src"],
+      "@local-office/lib/*": ["../../packages/lib/src/*"],
+      "@local-office/billing": ["../billing/src"],
+      "@local-office/billing/*": ["../billing/src/*"],
+      "@local-office/worker": ["./test/stubs/local-office-worker.ts"],
+      "@local-office/worker/*": ["./test/stubs/local-office-worker.ts"],
+      "@nestjs/common": ["./test/stubs/nestjs-common.ts"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- register a BillingService provider and BatchLockProducer so OrdersService can resolve external dependencies
- create Square payment intents during order confirmation, persist the resulting payment, and enqueue the batch lock job
- add Node-based integration tests with stubbed Square/Redis clients to cover payment persistence and job scheduling

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e15b2412a48321b93ef0be446ca237