### PR TITLE
Implement dispatcher vendor integrations and delivery event publishing

### DIFF
--- a/services/dispatcher/README.md
+++ b/services/dispatcher/README.md
@@ -3,6 +3,33 @@
 This service will manage courier integrations for Dispatch, Uber Direct, and Olo-originated orders. It will expose adapters that conform to a shared `CourierAdapter` interface and surface normalized delivery updates back to the core API.
 
 ## Integration notes
-- Maintain idempotency keys and retry policies for create/cancel operations
-- Verify and parse incoming webhooks for each vendor
-- Publish delivery status changes via the shared webhook-out channel
+- Maintain idempotency keys and retry policies for create/cancel operations.
+- Verify and parse incoming webhooks for each vendor.
+- Publish delivery status changes via the shared delivery update channel.
+
+## Required environment variables
+
+| Variable | Description |
+| --- | --- |
+| `DISPATCH_API_KEY` | API key used to authorize Dispatch HTTP requests. |
+| `DISPATCH_BASE_URL` | Base URL for the Dispatch REST API (e.g. `https://api.dispatch.me/v1`). |
+| `DISPATCH_WEBHOOK_SECRET` | Shared secret for validating Dispatch webhook signatures. |
+| `UBER_DIRECT_CLIENT_ID` | OAuth client ID for Uber Direct. |
+| `UBER_DIRECT_CLIENT_SECRET` | OAuth client secret for Uber Direct. |
+| `UBER_DIRECT_WEBHOOK_SECRET` | HMAC secret for Uber Direct webhooks. |
+| `UBER_DIRECT_BASE_URL` | Base URL for the Uber Direct delivery API (defaults to the production host when unset). |
+| `UBER_DIRECT_AUTH_URL` | OAuth token endpoint base URL (defaults to the production login host when unset). |
+| `OLO_API_KEY` | API key for Olo courier requests. |
+| `OLO_BASE_URL` | Base URL for Olo delivery operations. |
+| `OLO_WEBHOOK_SECRET` | HMAC secret shared by the Olo webhook integration. |
+| `REDIS_URL` / `DISPATCHER_REDIS_URL` | Connection string for the Redis instance backing the BullMQ delivery updates queue. |
+
+Set `DISPATCHER_REDIS_URL` when the dispatcher service should point to a Redis instance different from the default `REDIS_URL` used elsewhere.
+
+## Testing
+
+Integration tests mock the vendor APIs and verify request/response normalization, retry behaviour, signature verification, and BullMQ publishing hooks. Run them with:
+
+```bash
+pnpm --filter @local-office/dispatcher test
+```

--- a/services/dispatcher/package.json
+++ b/services/dispatcher/package.json
@@ -4,20 +4,24 @@
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js",
-    "dev": "ts-node --swc src/index.ts"
-  },
   "dependencies": {
     "@local-office/lib": "workspace:^",
     "axios": "1.7.7",
+    "bullmq": "5.29.0",
     "pino": "9.4.0"
   },
   "devDependencies": {
     "@types/express": "4.17.21",
     "@types/node": "20.16.10",
+    "nock": "14.0.4",
+    "ts-node": "10.9.2",
     "typescript": "5.6.3",
-    "ts-node": "10.9.2"
+    "vitest": "2.1.3"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "ts-node --swc src/index.ts",
+    "test": "vitest run"
   }
 }

--- a/services/dispatcher/src/adapters/__tests__/adapters.spec.ts
+++ b/services/dispatcher/src/adapters/__tests__/adapters.spec.ts
@@ -1,0 +1,299 @@
+import axios from 'axios';
+import httpAdapter from 'axios/lib/adapters/http.js';
+import type { Request } from 'express';
+import nock from 'nock';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DispatchAdapter } from '../dispatch';
+import { OloAdapter } from '../olo';
+import { UberDirectAdapter } from '../uberDirect';
+import { AdapterHttpError } from '../../utils/errors';
+import { createHmacDigest } from '../../utils/signature';
+
+axios.defaults.adapter = httpAdapter;
+process.env.HTTP_PROXY = '';
+process.env.http_proxy = '';
+process.env.HTTPS_PROXY = '';
+process.env.https_proxy = '';
+process.env.NO_PROXY = '*';
+process.env.no_proxy = '*';
+
+describe('Courier adapters', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    vi.clearAllMocks();
+  });
+
+  describe('DispatchAdapter', () => {
+    const publisher = vi.fn().mockResolvedValue(undefined);
+    let adapter: DispatchAdapter;
+
+    beforeEach(() => {
+      publisher.mockClear();
+      adapter = new DispatchAdapter({
+        apiKey: 'dispatch-key',
+        baseUrl: 'https://dispatch.example.com/',
+        webhookSecret: 'dispatch-secret',
+        publisher,
+        maxRetries: 1,
+        retryDelayMs: 0,
+        httpAdapter
+      });
+    });
+
+    it('requests quotes with retries and normalizes response', async () => {
+      nock('https://dispatch.example.com')
+        .post('/delivery/quotes')
+        .reply(500, { message: 'temporary error' })
+        .post('/delivery/quotes', (body) => {
+          expect(body.reference).toBe('order-123');
+          return true;
+        })
+        .reply(200, { price: { amount: 19.75, currency: 'USD' }, eta: { minutes: 42 } });
+
+      const result = await adapter.quote({
+        pickupAddress: '123 Start St',
+        dropoffAddress: '789 End Ave',
+        readyAt: '2024-01-01T10:00:00Z',
+        reference: 'order-123'
+      });
+
+      expect(result).toEqual({ fee: 19.75, currency: 'USD', etaMinutes: 42 });
+    });
+
+    it('translates HTTP errors', async () => {
+      nock('https://dispatch.example.com')
+        .post('/delivery/quotes')
+        .reply(400, { message: 'invalid address' });
+
+      await expect(
+        adapter.quote({
+          pickupAddress: 'bad',
+          dropoffAddress: 'dest',
+          readyAt: '2024-01-01T10:00:00Z',
+          reference: 'bad-order'
+        })
+      ).rejects.toBeInstanceOf(AdapterHttpError);
+    });
+
+    it('verifies webhook signatures and publishes delivery updates', async () => {
+      const payload = {
+        job_id: 'dispatch-1',
+        status: 'delivered',
+        timestamps: {
+          dispatched_at: '2024-01-01T10:00:00Z',
+          delivered_at: '2024-01-01T10:45:00Z'
+        },
+        proof: { url: 'https://dispatch.test/proof.jpg', type: 'photo' }
+      };
+      const rawBody = JSON.stringify(payload);
+      const signature = createHmacDigest({ payload: rawBody, secret: 'dispatch-secret' });
+
+      const req = buildRequest(payload, {
+        'x-dispatch-signature': signature
+      });
+      (req as any).rawBody = rawBody;
+
+      const update = await adapter.parseWebhook(req);
+
+      expect(update).toMatchObject({
+        provider: 'dispatch',
+        externalJobId: 'dispatch-1',
+        status: 'delivered'
+      });
+      expect(publisher).toHaveBeenCalledWith(expect.objectContaining({ externalJobId: 'dispatch-1' }));
+    });
+
+    it('rejects invalid webhook signatures', async () => {
+      const payload = { job_id: 'dispatch-1', status: 'delivered' };
+      const req = buildRequest(payload, {
+        'x-dispatch-signature': 'deadbeef'
+      });
+      (req as any).rawBody = JSON.stringify(payload);
+
+      await expect(adapter.parseWebhook(req)).rejects.toThrow('Invalid webhook signature');
+    });
+  });
+
+  describe('UberDirectAdapter', () => {
+    const publisher = vi.fn().mockResolvedValue(undefined);
+    let adapter: UberDirectAdapter;
+
+    beforeEach(() => {
+      publisher.mockClear();
+      adapter = new UberDirectAdapter({
+        clientId: 'uber-client',
+        clientSecret: 'uber-secret',
+        webhookSecret: 'uber-webhook',
+        baseUrl: 'https://uber.example.com/',
+        authUrl: 'https://login.uber.example.com/',
+        publisher,
+        maxRetries: 2,
+        retryDelayMs: 0,
+        httpAdapter
+      });
+    });
+
+    it('requests quotes after fetching an access token', async () => {
+      nock('https://login.uber.example.com')
+        .post('/oauth/v2/token')
+        .reply(200, { access_token: 'token-1', expires_in: 3600 });
+
+      nock('https://uber.example.com')
+        .post('/quotes')
+        .matchHeader('Authorization', 'Bearer token-1')
+        .reply(200, { price: { amount: 25.5, currency: 'USD' }, eta: { minutes: 30 } });
+
+      const result = await adapter.quote({
+        pickupAddress: 'Warehouse',
+        dropoffAddress: 'Customer',
+        readyAt: '2024-01-01T11:00:00Z',
+        reference: 'uber-order'
+      });
+
+      expect(result).toEqual({ fee: 25.5, currency: 'USD', etaMinutes: 30 });
+    });
+
+    it('refreshes the token when receiving a 401 response', async () => {
+      nock('https://login.uber.example.com')
+        .post('/oauth/v2/token')
+        .reply(200, { access_token: 'token-expired', expires_in: 3600 })
+        .post('/oauth/v2/token')
+        .reply(200, { access_token: 'token-fresh', expires_in: 3600 });
+
+      nock('https://uber.example.com')
+        .post('/deliveries')
+        .matchHeader('Authorization', 'Bearer token-expired')
+        .reply(401, { message: 'expired' })
+        .post('/deliveries')
+        .matchHeader('Authorization', 'Bearer token-fresh')
+        .reply(200, { delivery_id: 'uber-1', tracking_url: 'https://uber.test/track/uber-1' });
+
+      const result = await adapter.create({
+        pickupAddress: 'Warehouse',
+        dropoffAddress: 'Customer',
+        readyAt: '2024-01-01T11:00:00Z',
+        reference: 'uber-order',
+        contactEmail: 'ops@example.com',
+        contactPhone: '+123456789'
+      });
+
+      expect(result.externalJobId).toBe('uber-1');
+    });
+
+    it('verifies webhook payloads', async () => {
+      const payload = {
+        event: 'delivery.updated',
+        data: {
+          delivery_id: 'uber-99',
+          status: 'en_route',
+          timestamps: {
+            en_route_at: '2024-01-01T12:00:00Z'
+          }
+        }
+      };
+      const rawBody = JSON.stringify(payload);
+      const signature = createHmacDigest({ payload: rawBody, secret: 'uber-webhook' });
+
+      const req = buildRequest(payload, { 'x-uber-signature': signature });
+      (req as any).rawBody = rawBody;
+
+      const update = await adapter.parseWebhook(req);
+
+      expect(update).toMatchObject({ provider: 'uber-direct', externalJobId: 'uber-99', status: 'delivery.updated' });
+      expect(publisher).toHaveBeenCalledWith(expect.objectContaining({ externalJobId: 'uber-99' }));
+    });
+
+    it('rejects invalid Uber Direct signatures', async () => {
+      const payload = { delivery_id: 'uber-1' };
+      const req = buildRequest(payload, { 'x-uber-signature': 'bad' });
+      (req as any).rawBody = JSON.stringify(payload);
+
+      await expect(adapter.parseWebhook(req)).rejects.toThrow('Invalid webhook signature');
+    });
+  });
+
+  describe('OloAdapter', () => {
+    const publisher = vi.fn().mockResolvedValue(undefined);
+    let adapter: OloAdapter;
+
+    beforeEach(() => {
+      publisher.mockClear();
+      adapter = new OloAdapter({
+        apiKey: 'olo-key',
+        baseUrl: 'https://olo.example.com/',
+        webhookSecret: 'olo-secret',
+        publisher,
+        maxRetries: 1,
+        retryDelayMs: 0,
+        httpAdapter
+      });
+    });
+
+    it('creates deliveries via HTTP', async () => {
+      nock('https://olo.example.com')
+        .post('/deliveries')
+        .reply(200, { order_id: 'olo-123', tracking_url: 'https://olo.test/track/olo-123' });
+
+      const result = await adapter.create({
+        pickupAddress: 'Location A',
+        dropoffAddress: 'Location B',
+        readyAt: '2024-01-01T12:30:00Z',
+        reference: 'olo-order'
+      });
+
+      expect(result).toEqual({ externalJobId: 'olo-123', trackingUrl: 'https://olo.test/track/olo-123' });
+    });
+
+    it('verifies webhook signatures', async () => {
+      const payload = {
+        order_id: 'olo-77',
+        eventType: 'completed',
+        timestamps: {
+          completed_at: '2024-01-01T13:00:00Z'
+        }
+      };
+      const rawBody = JSON.stringify(payload);
+      const signature = createHmacDigest({ payload: rawBody, secret: 'olo-secret' });
+
+      const req = buildRequest(payload, { 'x-olo-signature': signature });
+      (req as any).rawBody = rawBody;
+
+      const update = await adapter.parseWebhook(req);
+
+      expect(update).toMatchObject({ provider: 'olo', externalJobId: 'olo-77', status: 'completed' });
+      expect(publisher).toHaveBeenCalledWith(expect.objectContaining({ externalJobId: 'olo-77' }));
+    });
+
+    it('rejects invalid Olo signatures', async () => {
+      const payload = { order_id: 'olo-1' };
+      const req = buildRequest(payload, { 'x-olo-signature': 'bad' });
+      (req as any).rawBody = JSON.stringify(payload);
+
+      await expect(adapter.parseWebhook(req)).rejects.toThrow('Invalid webhook signature');
+    });
+  });
+});
+
+function buildRequest(payload: any, headers: Record<string, string>): Request {
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  return {
+    body: payload,
+    headers: normalizedHeaders as any,
+    get(name: string) {
+      return normalizedHeaders[name.toLowerCase()];
+    }
+  } as unknown as Request;
+}

--- a/services/dispatcher/src/adapters/dispatch.ts
+++ b/services/dispatcher/src/adapters/dispatch.ts
@@ -1,35 +1,169 @@
+import axios, { type AxiosAdapter, type AxiosInstance } from 'axios';
 import type { Request } from 'express';
 import pino from 'pino';
 
-import type { CourierAdapter, CreateJobRequest, CreateJobResponse, DeliveryUpdate, QuoteRequest, QuoteResponse } from '..';
+import type {
+  CourierAdapter,
+  CreateJobRequest,
+  CreateJobResponse,
+  DeliveryUpdate,
+  QuoteRequest,
+  QuoteResponse
+} from '..';
+import { publishDeliveryUpdate, type DeliveryUpdatePublisher } from '../events/publisher';
+import { AdapterHttpError, translateAxiosError } from '../utils/errors';
+import { executeWithRetries } from '../utils/retry';
+import { assertValidHmacSignature } from '../utils/signature';
+import { getHeader, getRawBody, normalizeTimestamps } from '../utils/webhook';
 
 const logger = pino({ name: 'dispatch-adapter' });
 
+interface DispatchAdapterOptions {
+  apiKey: string;
+  baseUrl: string;
+  webhookSecret: string;
+  publisher?: DeliveryUpdatePublisher;
+  maxRetries?: number;
+  retryDelayMs?: number;
+  httpAdapter?: AxiosAdapter;
+}
+
 export class DispatchAdapter implements CourierAdapter {
-  constructor(private readonly apiKey: string, private readonly baseUrl: string) {}
+  private readonly client: AxiosInstance;
+  private readonly webhookSecret: string;
+  private readonly publish: DeliveryUpdatePublisher;
+  private readonly maxRetries: number;
+  private readonly retryDelayMs: number;
+
+  constructor(options: DispatchAdapterOptions) {
+    this.client = axios.create({
+      baseURL: options.baseUrl,
+      timeout: 10000,
+      headers: {
+        Authorization: `Bearer ${options.apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      adapter: options.httpAdapter
+    });
+    this.webhookSecret = options.webhookSecret;
+    this.publish = options.publisher ?? publishDeliveryUpdate;
+    this.maxRetries = options.maxRetries ?? 2;
+    this.retryDelayMs = options.retryDelayMs ?? 100;
+  }
 
   async quote(req: QuoteRequest): Promise<QuoteResponse> {
     logger.info({ req }, 'requesting Dispatch quote');
-    // Placeholder request — real implementation would call Dispatch API.
-    return { fee: 20, currency: 'USD', etaMinutes: 45 };
+
+    return executeWithRetries(async () => {
+      try {
+        const { data } = await this.client.post('/delivery/quotes', {
+          pickup: { address: req.pickupAddress },
+          dropoff: { address: req.dropoffAddress },
+          ready_at: req.readyAt,
+          reference: req.reference
+        });
+
+        const fee = Number(data?.price?.amount ?? data?.fee ?? data?.totalFee ?? 0);
+        const currency = String(data?.price?.currency ?? data?.currency ?? 'USD');
+        const etaMinutes = Number(data?.eta?.minutes ?? data?.etaMinutes ?? 0);
+
+        return { fee, currency, etaMinutes } satisfies QuoteResponse;
+      } catch (error) {
+        throw translateAxiosError('Dispatch', error);
+      }
+    }, {
+      retries: this.maxRetries,
+      baseDelayMs: this.retryDelayMs,
+      shouldRetry: (error) => error instanceof AdapterHttpError && error.retryable,
+      onRetry: (error, attempt) => logger.warn({ error, attempt }, 'retrying Dispatch quote request')
+    });
   }
 
   async create(job: CreateJobRequest): Promise<CreateJobResponse> {
     logger.info({ job }, 'creating Dispatch delivery');
-    return { externalJobId: `dispatch_${Date.now()}`, trackingUrl: 'https://dispatch.local/tracking/demo' };
+
+    return executeWithRetries(async () => {
+      try {
+        const { data } = await this.client.post('/delivery/jobs', {
+          pickup: { address: job.pickupAddress },
+          dropoff: { address: job.dropoffAddress },
+          ready_at: job.readyAt,
+          reference: job.reference,
+          contact: {
+            email: job.contactEmail,
+            phone: job.contactPhone
+          }
+        });
+
+        return {
+          externalJobId: String(data?.id ?? data?.job_id ?? ''),
+          trackingUrl: data?.tracking_url ?? data?.trackingUrl
+        } satisfies CreateJobResponse;
+      } catch (error) {
+        throw translateAxiosError('Dispatch', error);
+      }
+    }, {
+      retries: this.maxRetries,
+      baseDelayMs: this.retryDelayMs,
+      shouldRetry: (error) => error instanceof AdapterHttpError && error.retryable,
+      onRetry: (error, attempt) => logger.warn({ error, attempt }, 'retrying Dispatch create request')
+    });
   }
 
   async cancel(externalJobId: string): Promise<void> {
     logger.info({ externalJobId }, 'cancel Dispatch job');
+
+    await executeWithRetries(async () => {
+      try {
+        await this.client.post(`/delivery/jobs/${encodeURIComponent(externalJobId)}/cancel`);
+      } catch (error) {
+        throw translateAxiosError('Dispatch', error);
+      }
+    }, {
+      retries: this.maxRetries,
+      baseDelayMs: this.retryDelayMs,
+      shouldRetry: (error) => error instanceof AdapterHttpError && error.retryable,
+      onRetry: (error, attempt) => logger.warn({ error, attempt }, 'retrying Dispatch cancel request')
+    });
   }
 
-  parseWebhook(req: Request): DeliveryUpdate {
-    const payload = req.body as Record<string, any>;
-    logger.info({ payload }, 'received Dispatch webhook');
-    return {
-      status: payload.status ?? 'unknown',
-      timestamps: payload.timestamps ?? {},
+  async parseWebhook(req: Request): Promise<DeliveryUpdate> {
+    const payload = (req.body ?? {}) as Record<string, any>;
+    const body = getRawBody(req) ?? JSON.stringify(payload);
+    const signatureHeader = getHeader(req, 'x-dispatch-signature');
+
+    if (!signatureHeader) {
+      throw new Error('Missing x-dispatch-signature header');
+    }
+
+    assertValidHmacSignature({
+      payload: body,
+      secret: this.webhookSecret,
+      signature: signatureHeader
+    });
+
+    const externalJobId = String(payload.job_id ?? payload.delivery_id ?? payload.id ?? '');
+
+    if (!externalJobId) {
+      throw new Error('Dispatch webhook missing job identifier');
+    }
+
+    const update: DeliveryUpdate = {
+      provider: 'dispatch',
+      externalJobId,
+      status: String(payload.status ?? payload.state ?? 'unknown'),
+      timestamps: normalizeTimestamps(payload.timestamps ?? payload.timeline ?? {}),
       proof: payload.proof
+        ? {
+            url: String(payload.proof.url),
+            type: String(payload.proof.type ?? 'photo')
+          }
+        : undefined,
+      rawPayload: payload
     };
+
+    await this.publish(update);
+
+    return update;
   }
 }

--- a/services/dispatcher/src/adapters/olo.ts
+++ b/services/dispatcher/src/adapters/olo.ts
@@ -1,32 +1,169 @@
+import axios, { type AxiosAdapter, type AxiosInstance } from 'axios';
 import type { Request } from 'express';
 import pino from 'pino';
 
-import type { CourierAdapter, CreateJobRequest, CreateJobResponse, DeliveryUpdate, QuoteRequest, QuoteResponse } from '..';
+import type {
+  CourierAdapter,
+  CreateJobRequest,
+  CreateJobResponse,
+  DeliveryUpdate,
+  QuoteRequest,
+  QuoteResponse
+} from '..';
+import { publishDeliveryUpdate, type DeliveryUpdatePublisher } from '../events/publisher';
+import { AdapterHttpError, translateAxiosError } from '../utils/errors';
+import { executeWithRetries } from '../utils/retry';
+import { assertValidHmacSignature } from '../utils/signature';
+import { getHeader, getRawBody, normalizeTimestamps } from '../utils/webhook';
 
 const logger = pino({ name: 'olo-adapter' });
 
+interface OloAdapterOptions {
+  apiKey: string;
+  baseUrl: string;
+  webhookSecret: string;
+  publisher?: DeliveryUpdatePublisher;
+  maxRetries?: number;
+  retryDelayMs?: number;
+  httpAdapter?: AxiosAdapter;
+}
+
 export class OloAdapter implements CourierAdapter {
+  private readonly client: AxiosInstance;
+  private readonly webhookSecret: string;
+  private readonly publish: DeliveryUpdatePublisher;
+  private readonly maxRetries: number;
+  private readonly retryDelayMs: number;
+
+  constructor(options: OloAdapterOptions) {
+    this.client = axios.create({
+      baseURL: options.baseUrl,
+      timeout: 10000,
+      headers: {
+        Authorization: `Bearer ${options.apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      adapter: options.httpAdapter
+    });
+    this.webhookSecret = options.webhookSecret;
+    this.publish = options.publisher ?? publishDeliveryUpdate;
+    this.maxRetries = options.maxRetries ?? 2;
+    this.retryDelayMs = options.retryDelayMs ?? 100;
+  }
+
   async quote(req: QuoteRequest): Promise<QuoteResponse> {
-    logger.info({ req }, 'returning stub Olo quote');
-    return { fee: 0, currency: 'USD', etaMinutes: 0 };
+    logger.info({ req }, 'requesting Olo quote');
+
+    return executeWithRetries(async () => {
+      try {
+        const { data } = await this.client.post('/deliveries/quotes', {
+          pickup: { address: req.pickupAddress },
+          dropoff: { address: req.dropoffAddress },
+          ready_at: req.readyAt,
+          reference: req.reference
+        });
+
+        const fee = Number(data?.price?.amount ?? data?.fee ?? 0);
+        const currency = String(data?.price?.currency ?? data?.currency ?? 'USD');
+        const etaMinutes = Number(data?.eta?.minutes ?? data?.etaMinutes ?? 0);
+
+        return { fee, currency, etaMinutes } satisfies QuoteResponse;
+      } catch (error) {
+        throw translateAxiosError('Olo', error);
+      }
+    }, {
+      retries: this.maxRetries,
+      baseDelayMs: this.retryDelayMs,
+      shouldRetry: (error) => error instanceof AdapterHttpError && error.retryable,
+      onRetry: (error, attempt) => logger.warn({ error, attempt }, 'retrying Olo quote request')
+    });
   }
 
   async create(job: CreateJobRequest): Promise<CreateJobResponse> {
-    logger.info({ job }, 'Olo order create stub');
-    return { externalJobId: `olo_${Date.now()}` };
+    logger.info({ job }, 'creating Olo delivery');
+
+    return executeWithRetries(async () => {
+      try {
+        const { data } = await this.client.post('/deliveries', {
+          pickup: { address: job.pickupAddress },
+          dropoff: { address: job.dropoffAddress },
+          ready_at: job.readyAt,
+          reference: job.reference,
+          contact: {
+            email: job.contactEmail,
+            phone: job.contactPhone
+          }
+        });
+
+        return {
+          externalJobId: String(data?.order_id ?? data?.id ?? ''),
+          trackingUrl: data?.tracking_url ?? data?.trackingUrl
+        } satisfies CreateJobResponse;
+      } catch (error) {
+        throw translateAxiosError('Olo', error);
+      }
+    }, {
+      retries: this.maxRetries,
+      baseDelayMs: this.retryDelayMs,
+      shouldRetry: (error) => error instanceof AdapterHttpError && error.retryable,
+      onRetry: (error, attempt) => logger.warn({ error, attempt }, 'retrying Olo create request')
+    });
   }
 
   async cancel(externalJobId: string): Promise<void> {
-    logger.info({ externalJobId }, 'Olo cancel stub');
+    logger.info({ externalJobId }, 'cancel Olo delivery');
+
+    await executeWithRetries(async () => {
+      try {
+        await this.client.post(`/deliveries/${encodeURIComponent(externalJobId)}/cancel`);
+      } catch (error) {
+        throw translateAxiosError('Olo', error);
+      }
+    }, {
+      retries: this.maxRetries,
+      baseDelayMs: this.retryDelayMs,
+      shouldRetry: (error) => error instanceof AdapterHttpError && error.retryable,
+      onRetry: (error, attempt) => logger.warn({ error, attempt }, 'retrying Olo cancel request')
+    });
   }
 
-  parseWebhook(req: Request): DeliveryUpdate {
-    const payload = req.body as Record<string, any>;
-    logger.info({ payload }, 'Olo webhook stub');
-    return {
-      status: payload.eventType ?? 'received',
-      timestamps: payload.timestamps ?? {},
+  async parseWebhook(req: Request): Promise<DeliveryUpdate> {
+    const payload = (req.body ?? {}) as Record<string, any>;
+    const body = getRawBody(req) ?? JSON.stringify(payload);
+    const signature = getHeader(req, 'x-olo-signature');
+
+    if (!signature) {
+      throw new Error('Missing x-olo-signature header');
+    }
+
+    assertValidHmacSignature({
+      payload: body,
+      secret: this.webhookSecret,
+      signature
+    });
+
+    const externalJobId = String(payload.order_id ?? payload.id ?? '');
+
+    if (!externalJobId) {
+      throw new Error('Olo webhook missing order identifier');
+    }
+
+    const update: DeliveryUpdate = {
+      provider: 'olo',
+      externalJobId,
+      status: String(payload.eventType ?? payload.status ?? 'received'),
+      timestamps: normalizeTimestamps(payload.timestamps ?? payload.timeline),
       proof: payload.proof
+        ? {
+            url: String(payload.proof.url),
+            type: String(payload.proof.type ?? 'photo')
+          }
+        : undefined,
+      rawPayload: payload
     };
+
+    await this.publish(update);
+
+    return update;
   }
 }

--- a/services/dispatcher/src/adapters/uberDirect.ts
+++ b/services/dispatcher/src/adapters/uberDirect.ts
@@ -1,34 +1,264 @@
+import axios, { type AxiosAdapter, AxiosInstance, isAxiosError } from 'axios';
 import type { Request } from 'express';
 import pino from 'pino';
 
-import type { CourierAdapter, CreateJobRequest, CreateJobResponse, DeliveryUpdate, QuoteRequest, QuoteResponse } from '..';
+import type {
+  CourierAdapter,
+  CreateJobRequest,
+  CreateJobResponse,
+  DeliveryUpdate,
+  QuoteRequest,
+  QuoteResponse
+} from '..';
+import { publishDeliveryUpdate, type DeliveryUpdatePublisher } from '../events/publisher';
+import { AdapterHttpError, translateAxiosError } from '../utils/errors';
+import { executeWithRetries } from '../utils/retry';
+import { assertValidHmacSignature } from '../utils/signature';
+import { getHeader, getRawBody, normalizeTimestamps } from '../utils/webhook';
 
 const logger = pino({ name: 'uber-direct-adapter' });
 
+interface UberDirectAdapterOptions {
+  clientId: string;
+  clientSecret: string;
+  webhookSecret: string;
+  baseUrl?: string;
+  authUrl?: string;
+  scope?: string;
+  publisher?: DeliveryUpdatePublisher;
+  maxRetries?: number;
+  retryDelayMs?: number;
+  httpAdapter?: AxiosAdapter;
+}
+
+interface UberAccessToken {
+  token: string;
+  expiresAt: number;
+}
+
 export class UberDirectAdapter implements CourierAdapter {
-  constructor(private readonly clientId: string, private readonly clientSecret: string) {}
+  private readonly apiClient: AxiosInstance;
+  private readonly authClient: AxiosInstance;
+  private readonly webhookSecret: string;
+  private readonly publish: DeliveryUpdatePublisher;
+  private readonly scope: string;
+  private readonly maxRetries: number;
+  private readonly retryDelayMs: number;
+  private accessToken?: UberAccessToken;
+
+  constructor(private readonly options: UberDirectAdapterOptions) {
+    this.apiClient = axios.create({
+      baseURL: options.baseUrl ?? 'https://api.uber.com/v1/direct-deliveries',
+      timeout: 10000,
+      adapter: options.httpAdapter
+    });
+    this.authClient = axios.create({
+      baseURL: options.authUrl ?? 'https://login.uber.com',
+      timeout: 10000,
+      adapter: options.httpAdapter
+    });
+    this.webhookSecret = options.webhookSecret;
+    this.publish = options.publisher ?? publishDeliveryUpdate;
+    this.scope = options.scope ?? 'delivery';
+    this.maxRetries = options.maxRetries ?? 2;
+    this.retryDelayMs = options.retryDelayMs ?? 100;
+  }
 
   async quote(req: QuoteRequest): Promise<QuoteResponse> {
     logger.info({ req }, 'requesting Uber Direct quote');
-    return { fee: 24, currency: 'USD', etaMinutes: 35 };
+    return executeWithRetries(async () => {
+      const token = await this.getAccessToken();
+      try {
+        const { data } = await this.apiClient.post(
+          '/quotes',
+          {
+            pickup: { address: req.pickupAddress },
+            dropoff: { address: req.dropoffAddress },
+            ready_by: req.readyAt,
+            reference: req.reference
+          },
+          {
+            headers: { Authorization: `Bearer ${token}` }
+          }
+        );
+
+        const fee = Number(data?.price?.amount ?? data?.fee ?? 0);
+        const currency = String(data?.price?.currency ?? data?.currency ?? 'USD');
+        const etaMinutes = Number(data?.eta?.minutes ?? data?.etaMinutes ?? 0);
+
+        return { fee, currency, etaMinutes } satisfies QuoteResponse;
+      } catch (error) {
+        if (isAxiosError(error) && (error.response?.status === 401 || error.response?.status === 403)) {
+          this.accessToken = undefined;
+          throw new AdapterHttpError('Uber Direct', 'Authentication failed', {
+            status: error.response?.status,
+            code: error.code,
+            retryable: true,
+            details: error.response?.data
+          });
+        }
+
+        throw translateAxiosError('Uber Direct', error);
+      }
+    }, {
+      retries: this.maxRetries,
+      baseDelayMs: this.retryDelayMs,
+      shouldRetry: (error) => error instanceof AdapterHttpError && error.retryable,
+      onRetry: (error, attempt) => logger.warn({ error, attempt }, 'retrying Uber Direct quote request')
+    });
   }
 
   async create(job: CreateJobRequest): Promise<CreateJobResponse> {
     logger.info({ job }, 'creating Uber Direct job');
-    return { externalJobId: `uber_${Date.now()}`, trackingUrl: 'https://direct.uber.com/track/demo' };
+    return executeWithRetries(async () => {
+      const token = await this.getAccessToken();
+      try {
+        const { data } = await this.apiClient.post(
+          '/deliveries',
+          {
+            pickup: { address: job.pickupAddress },
+            dropoff: { address: job.dropoffAddress },
+            ready_by: job.readyAt,
+            reference: job.reference,
+            contact: {
+              email: job.contactEmail,
+              phone: job.contactPhone
+            }
+          },
+          {
+            headers: { Authorization: `Bearer ${token}` }
+          }
+        );
+
+        return {
+          externalJobId: String(data?.delivery_id ?? data?.id ?? ''),
+          trackingUrl: data?.tracking_url ?? data?.trackingUrl
+        } satisfies CreateJobResponse;
+      } catch (error) {
+        if (isAxiosError(error) && (error.response?.status === 401 || error.response?.status === 403)) {
+          this.accessToken = undefined;
+          throw new AdapterHttpError('Uber Direct', 'Authentication failed', {
+            status: error.response?.status,
+            code: error.code,
+            retryable: true,
+            details: error.response?.data
+          });
+        }
+
+        throw translateAxiosError('Uber Direct', error);
+      }
+    }, {
+      retries: this.maxRetries,
+      baseDelayMs: this.retryDelayMs,
+      shouldRetry: (error) => error instanceof AdapterHttpError && error.retryable,
+      onRetry: (error, attempt) => logger.warn({ error, attempt }, 'retrying Uber Direct create request')
+    });
   }
 
   async cancel(externalJobId: string): Promise<void> {
     logger.info({ externalJobId }, 'cancel Uber Direct job');
+    await executeWithRetries(async () => {
+      const token = await this.getAccessToken();
+      try {
+        await this.apiClient.post(
+          `/deliveries/${encodeURIComponent(externalJobId)}/cancel`,
+          {},
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+      } catch (error) {
+        if (isAxiosError(error) && (error.response?.status === 401 || error.response?.status === 403)) {
+          this.accessToken = undefined;
+          throw new AdapterHttpError('Uber Direct', 'Authentication failed', {
+            status: error.response?.status,
+            code: error.code,
+            retryable: true,
+            details: error.response?.data
+          });
+        }
+
+        throw translateAxiosError('Uber Direct', error);
+      }
+    }, {
+      retries: this.maxRetries,
+      baseDelayMs: this.retryDelayMs,
+      shouldRetry: (error) => error instanceof AdapterHttpError && error.retryable,
+      onRetry: (error, attempt) => logger.warn({ error, attempt }, 'retrying Uber Direct cancel request')
+    });
   }
 
-  parseWebhook(req: Request): DeliveryUpdate {
-    const payload = req.body as Record<string, any>;
-    logger.info({ payload }, 'received Uber Direct webhook');
-    return {
-      status: payload.event ?? 'unknown',
-      timestamps: payload.timestamps ?? {},
-      proof: payload.proof
+  async parseWebhook(req: Request): Promise<DeliveryUpdate> {
+    const payload = (req.body ?? {}) as Record<string, any>;
+    const body = getRawBody(req) ?? JSON.stringify(payload);
+    const signature = getHeader(req, 'x-uber-signature');
+
+    if (!signature) {
+      throw new Error('Missing x-uber-signature header');
+    }
+
+    assertValidHmacSignature({
+      payload: body,
+      secret: this.webhookSecret,
+      signature
+    });
+
+    const data = payload.data ?? payload;
+    const externalJobId = String(data.delivery_id ?? data.id ?? '');
+
+    if (!externalJobId) {
+      throw new Error('Uber Direct webhook missing delivery identifier');
+    }
+
+    const update: DeliveryUpdate = {
+      provider: 'uber-direct',
+      externalJobId,
+      status: String(payload.event ?? payload.event_type ?? data.status ?? 'unknown'),
+      timestamps: normalizeTimestamps(data.timestamps),
+      proof: data.proof
+        ? {
+            url: String(data.proof.url),
+            type: String(data.proof.type ?? 'photo')
+          }
+        : undefined,
+      rawPayload: payload
     };
+
+    await this.publish(update);
+
+    return update;
+  }
+
+  private async getAccessToken(): Promise<string> {
+    if (this.accessToken && this.accessToken.expiresAt > Date.now() + 60_000) {
+      return this.accessToken.token;
+    }
+
+    try {
+      const params = new URLSearchParams({
+        grant_type: 'client_credentials',
+        scope: this.scope,
+        client_id: this.options.clientId,
+        client_secret: this.options.clientSecret
+      });
+
+      const { data } = await this.authClient.post('/oauth/v2/token', params.toString(), {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+      });
+
+      const token = String(data?.access_token ?? '');
+      const expiresIn = Number(data?.expires_in ?? 3600);
+
+      if (!token) {
+        throw new Error('Uber Direct auth response missing access token');
+      }
+
+      this.accessToken = {
+        token,
+        expiresAt: Date.now() + expiresIn * 1000
+      };
+
+      return token;
+    } catch (error) {
+      throw translateAxiosError('Uber Direct Auth', error);
+    }
   }
 }

--- a/services/dispatcher/src/events/publisher.ts
+++ b/services/dispatcher/src/events/publisher.ts
@@ -1,0 +1,67 @@
+import { Queue } from 'bullmq';
+import pino from 'pino';
+
+import type { DeliveryUpdate } from '..';
+
+const logger = pino({ name: 'delivery-update-publisher' });
+
+export interface DeliveryUpdateEvent extends DeliveryUpdate {
+  receivedAt: string;
+}
+
+export interface DeliveryUpdateTransport {
+  send(event: DeliveryUpdateEvent): Promise<void>;
+}
+
+export type DeliveryUpdatePublisher = (update: DeliveryUpdate) => Promise<void>;
+
+class BullMqTransport implements DeliveryUpdateTransport {
+  private readonly queue: Queue<DeliveryUpdateEvent>;
+
+  constructor() {
+    const url = process.env.DISPATCHER_REDIS_URL ?? process.env.REDIS_URL ?? 'redis://localhost:6379';
+    this.queue = new Queue<DeliveryUpdateEvent>('delivery-updates', {
+      connection: {
+        url,
+        lazyConnect: true
+      }
+    });
+  }
+
+  async send(event: DeliveryUpdateEvent): Promise<void> {
+    await this.queue.add('delivery-update', event, {
+      attempts: 5,
+      backoff: { type: 'exponential', delay: 1000 },
+      removeOnComplete: true,
+      removeOnFail: 100
+    });
+  }
+}
+
+let transport: DeliveryUpdateTransport | null = null;
+
+function resolveTransport(): DeliveryUpdateTransport {
+  if (!transport) {
+    transport = new BullMqTransport();
+  }
+
+  return transport;
+}
+
+export function setDeliveryUpdateTransport(custom: DeliveryUpdateTransport | null): void {
+  transport = custom;
+}
+
+export const publishDeliveryUpdate: DeliveryUpdatePublisher = async (update) => {
+  const event: DeliveryUpdateEvent = {
+    ...update,
+    receivedAt: new Date().toISOString()
+  };
+
+  try {
+    await resolveTransport().send(event);
+  } catch (error) {
+    logger.error({ error, event }, 'failed to publish delivery update');
+    throw error;
+  }
+};

--- a/services/dispatcher/src/index.ts
+++ b/services/dispatcher/src/index.ts
@@ -28,19 +28,22 @@ export interface CreateJobResponse {
 }
 
 export interface DeliveryUpdate {
+  provider: string;
+  externalJobId: string;
   status: string;
   timestamps: Record<string, string | undefined>;
   proof?: {
     url: string;
     type: string;
   };
+  rawPayload: unknown;
 }
 
 export interface CourierAdapter {
   quote(req: QuoteRequest): Promise<QuoteResponse>;
   create(job: CreateJobRequest): Promise<CreateJobResponse>;
   cancel(externalJobId: string): Promise<void>;
-  parseWebhook(req: Request): DeliveryUpdate;
+  parseWebhook(req: Request): Promise<DeliveryUpdate>;
 }
 
 export type AdapterRegistry = Record<string, CourierAdapter>;

--- a/services/dispatcher/src/utils/errors.ts
+++ b/services/dispatcher/src/utils/errors.ts
@@ -1,0 +1,67 @@
+import type { AxiosError } from 'axios';
+import { isAxiosError } from 'axios';
+
+export class AdapterHttpError extends Error {
+  readonly provider: string;
+  readonly status?: number;
+  readonly code?: string;
+  readonly retryable: boolean;
+  readonly details?: unknown;
+
+  constructor(provider: string, message: string, options: {
+    status?: number;
+    code?: string;
+    retryable?: boolean;
+    details?: unknown;
+  } = {}) {
+    super(`[${provider}] ${message}`);
+    this.name = 'AdapterHttpError';
+    this.provider = provider;
+    this.status = options.status;
+    this.code = options.code;
+    this.retryable = options.retryable ?? false;
+    this.details = options.details;
+  }
+}
+
+export function translateAxiosError(provider: string, error: unknown): AdapterHttpError {
+  if (isAxiosError(error)) {
+    return fromAxiosError(provider, error);
+  }
+
+  if (error instanceof Error) {
+    return new AdapterHttpError(provider, error.message, { details: { stack: error.stack } });
+  }
+
+  return new AdapterHttpError(provider, 'Unknown error', { details: error });
+}
+
+function fromAxiosError(provider: string, error: AxiosError): AdapterHttpError {
+  const status = error.response?.status;
+  const message =
+    (typeof error.response?.data === 'object' && error.response?.data !== null && 'message' in (error.response?.data as any)
+      ? String((error.response?.data as any).message)
+      : error.message) ?? 'HTTP request failed';
+
+  const retryable = determineRetryable(error);
+
+  return new AdapterHttpError(provider, message, {
+    status,
+    code: error.code,
+    retryable,
+    details: {
+      data: error.response?.data,
+      headers: error.response?.headers,
+      requestId: (error.response?.headers as Record<string, string> | undefined)?.['x-request-id']
+    }
+  });
+}
+
+function determineRetryable(error: AxiosError): boolean {
+  if (!error.response) {
+    return true;
+  }
+
+  const status = error.response.status ?? 0;
+  return status >= 500 || status === 429;
+}

--- a/services/dispatcher/src/utils/retry.ts
+++ b/services/dispatcher/src/utils/retry.ts
@@ -1,0 +1,39 @@
+export interface RetryOptions {
+  retries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  shouldRetry?: (error: unknown) => boolean;
+  onRetry?: (error: unknown, attempt: number) => void;
+}
+
+export async function executeWithRetries<T>(operation: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  const retries = options.retries ?? 2;
+  const baseDelayMs = options.baseDelayMs ?? 50;
+  const maxDelayMs = options.maxDelayMs ?? 1000;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      const shouldRetry = options.shouldRetry?.(error) ?? false;
+
+      if (!shouldRetry || attempt === retries) {
+        throw error;
+      }
+
+      const delay = Math.min(baseDelayMs * Math.pow(2, attempt), maxDelayMs);
+      options.onRetry?.(error, attempt + 1);
+      await delayFor(delay);
+    }
+  }
+
+  throw new Error('Retry attempts exhausted');
+}
+
+async function delayFor(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/services/dispatcher/src/utils/signature.ts
+++ b/services/dispatcher/src/utils/signature.ts
@@ -1,0 +1,45 @@
+import crypto from 'crypto';
+
+export interface HmacSignatureOptions {
+  payload: string;
+  secret: string;
+  signature: string;
+  algorithm?: string;
+  encoding?: crypto.BinaryToTextEncoding;
+}
+
+export function verifyHmacSignature(options: HmacSignatureOptions): boolean {
+  const digest = createHmacDigest({
+    payload: options.payload,
+    secret: options.secret,
+    algorithm: options.algorithm,
+    encoding: options.encoding
+  });
+
+  const expected = Buffer.from(digest, options.encoding ?? 'hex');
+  const received = Buffer.from(options.signature, options.encoding ?? 'hex');
+
+  if (expected.length !== received.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(expected, received);
+}
+
+export function assertValidHmacSignature(options: HmacSignatureOptions): void {
+  if (!verifyHmacSignature(options)) {
+    throw new Error('Invalid webhook signature');
+  }
+}
+
+export function createHmacDigest(options: {
+  payload: string;
+  secret: string;
+  algorithm?: string;
+  encoding?: crypto.BinaryToTextEncoding;
+}): string {
+  const algorithm = options.algorithm ?? 'sha256';
+  const encoding = options.encoding ?? 'hex';
+
+  return crypto.createHmac(algorithm, options.secret).update(options.payload, 'utf8').digest(encoding);
+}

--- a/services/dispatcher/src/utils/webhook.ts
+++ b/services/dispatcher/src/utils/webhook.ts
@@ -1,0 +1,34 @@
+import type { Request } from 'express';
+
+export function getHeader(req: Request, name: string): string | undefined {
+  const header =
+    req.get?.(name) ??
+    (req.headers?.[name] as string | undefined) ??
+    (req.headers?.[name.toLowerCase()] as string | undefined) ??
+    undefined;
+
+  return header;
+}
+
+export function getRawBody(req: Request): string | undefined {
+  const raw = (req as any).rawBody;
+  if (typeof raw === 'string') {
+    return raw;
+  }
+
+  if (Buffer.isBuffer(raw)) {
+    return raw.toString('utf8');
+  }
+
+  return undefined;
+}
+
+export function normalizeTimestamps(input: Record<string, any> | undefined): Record<string, string | undefined> {
+  if (!input) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [key, value != null ? String(value) : undefined])
+  );
+}

--- a/services/dispatcher/vitest.config.ts
+++ b/services/dispatcher/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.spec.ts', 'test/**/*.spec.ts'],
+    coverage: {
+      reporter: ['text', 'lcov'],
+      enabled: false
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- replace placeholder adapters with axios clients for Dispatch, Uber Direct, and Olo including retry and error handling
- add shared HMAC verification utilities and BullMQ publisher for delivery update events
- document required secrets/env vars and add Vitest integration coverage with mocked vendor APIs

## Testing
- `pnpm --filter @local-office/dispatcher test`


------
https://chatgpt.com/codex/tasks/task_e_68e15b2a2a4483218f157fe97ed5c6da