### PR TITLE
fix: align package manager with pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ajv": "6.12.6",
     "ajv-keywords": "3.5.2"
   },
-  "packageManager": "npm@10.8.1",
+  "packageManager": "pnpm@9.12.3",
   "engines": {
     "node": "20.x"
   },


### PR DESCRIPTION
## Summary
- update the package manager metadata to pnpm so automated installs match the lockfile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e165ced2208321823d5aded3e38d08