### PR TITLE
Add deliveries module for courier orchestration

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@local-office/billing": "workspace:^",
+    "@local-office/dispatcher": "workspace:^",
     "@local-office/db": "workspace:^",
     "@local-office/lib": "workspace:^",
     "@local-office/worker": "workspace:^",

--- a/services/api/src/modules/app.module.ts
+++ b/services/api/src/modules/app.module.ts
@@ -8,6 +8,7 @@ import { BatchesModule } from './batches/batches.module';
 import { IncidentsModule } from './incidents/incidents.module';
 import { ReferralsModule } from './referrals/referrals.module';
 import { InvoicesModule } from './invoices/invoices.module';
+import { DeliveriesModule } from './deliveries/deliveries.module';
 
 @Module({
   imports: [
@@ -18,7 +19,8 @@ import { InvoicesModule } from './invoices/invoices.module';
     BatchesModule,
     IncidentsModule,
     ReferralsModule,
-    InvoicesModule
+    InvoicesModule,
+    DeliveriesModule
   ]
 })
 export class AppModule {}

--- a/services/api/src/modules/deliveries/deliveries.constants.ts
+++ b/services/api/src/modules/deliveries/deliveries.constants.ts
@@ -1,0 +1,10 @@
+export const DELIVERY_ADAPTERS = Symbol('DELIVERY_ADAPTERS');
+export const DELIVERY_UPDATES_QUEUE = Symbol('DELIVERY_UPDATES_QUEUE');
+export const DELIVERY_UPDATES_QUEUE_NAME = 'delivery-updates';
+export const DELIVERY_UPDATE_JOB_NAME = 'delivery-update';
+
+export const queueConnection = {
+  connection: {
+    url: process.env.REDIS_URL ?? 'redis://localhost:6379'
+  }
+};

--- a/services/api/src/modules/deliveries/deliveries.controller.ts
+++ b/services/api/src/modules/deliveries/deliveries.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Delete, Param, Post } from '@nestjs/common';
+
+import { DeliveriesService } from './deliveries.service';
+import { CreateDeliveryDto } from './dto/create-delivery.dto';
+import { QuoteDeliveryDto } from './dto/quote-delivery.dto';
+
+@Controller('batches')
+export class DeliveriesController {
+  constructor(private readonly deliveriesService: DeliveriesService) {}
+
+  @Post(':batchId/deliveries/quote')
+  quote(@Param('batchId') batchId: string, @Body() dto: QuoteDeliveryDto) {
+    return this.deliveriesService.quote(batchId, dto);
+  }
+
+  @Post(':batchId/deliveries')
+  create(@Param('batchId') batchId: string, @Body() dto: CreateDeliveryDto) {
+    return this.deliveriesService.create(batchId, dto);
+  }
+
+  @Delete(':batchId/deliveries')
+  cancel(@Param('batchId') batchId: string) {
+    return this.deliveriesService.cancel(batchId);
+  }
+}

--- a/services/api/src/modules/deliveries/deliveries.module.ts
+++ b/services/api/src/modules/deliveries/deliveries.module.ts
@@ -1,0 +1,81 @@
+import { Injectable, Module, OnModuleDestroy } from '@nestjs/common';
+import { Queue } from 'bullmq';
+import type { AdapterRegistry } from '@local-office/dispatcher';
+import { DispatchAdapter, OloAdapter, UberDirectAdapter } from '@local-office/dispatcher/adapters';
+
+import { DeliveriesController } from './deliveries.controller';
+import { DeliveriesService } from './deliveries.service';
+import {
+  DELIVERY_ADAPTERS,
+  DELIVERY_UPDATES_QUEUE,
+  DELIVERY_UPDATES_QUEUE_NAME,
+  queueConnection
+} from './deliveries.constants';
+
+function buildAdapterRegistry(): AdapterRegistry {
+  const registry: AdapterRegistry = {};
+
+  if (process.env.DISPATCH_API_KEY && process.env.DISPATCH_BASE_URL && process.env.DISPATCH_WEBHOOK_SECRET) {
+    registry['dispatch'] = new DispatchAdapter({
+      apiKey: process.env.DISPATCH_API_KEY,
+      baseUrl: process.env.DISPATCH_BASE_URL,
+      webhookSecret: process.env.DISPATCH_WEBHOOK_SECRET
+    });
+  }
+
+  if (
+    process.env.UBER_DIRECT_CLIENT_ID &&
+    process.env.UBER_DIRECT_CLIENT_SECRET &&
+    process.env.UBER_DIRECT_WEBHOOK_SECRET
+  ) {
+    const baseUrl = process.env.UBER_DIRECT_BASE_URL;
+    const authUrl = process.env.UBER_DIRECT_AUTH_URL;
+    const scope = process.env.UBER_DIRECT_SCOPE;
+
+    registry['uber-direct'] = new UberDirectAdapter({
+      clientId: process.env.UBER_DIRECT_CLIENT_ID,
+      clientSecret: process.env.UBER_DIRECT_CLIENT_SECRET,
+      webhookSecret: process.env.UBER_DIRECT_WEBHOOK_SECRET,
+      ...(baseUrl ? { baseUrl } : {}),
+      ...(authUrl ? { authUrl } : {}),
+      ...(scope ? { scope } : {})
+    });
+  }
+
+  if (process.env.OLO_API_KEY && process.env.OLO_BASE_URL && process.env.OLO_WEBHOOK_SECRET) {
+    registry['olo'] = new OloAdapter({
+      apiKey: process.env.OLO_API_KEY,
+      baseUrl: process.env.OLO_BASE_URL,
+      webhookSecret: process.env.OLO_WEBHOOK_SECRET
+    });
+  }
+
+  return registry;
+}
+
+@Injectable()
+class DeliveryUpdatesQueueProvider implements OnModuleDestroy {
+  readonly queue = new Queue(DELIVERY_UPDATES_QUEUE_NAME, queueConnection);
+
+  async onModuleDestroy() {
+    await this.queue.close();
+  }
+}
+
+@Module({
+  controllers: [DeliveriesController],
+  providers: [
+    DeliveriesService,
+    DeliveryUpdatesQueueProvider,
+    {
+      provide: DELIVERY_UPDATES_QUEUE,
+      useFactory: (provider: DeliveryUpdatesQueueProvider) => provider.queue,
+      inject: [DeliveryUpdatesQueueProvider]
+    },
+    {
+      provide: DELIVERY_ADAPTERS,
+      useFactory: () => buildAdapterRegistry()
+    }
+  ]
+})
+export class DeliveriesModule {}

--- a/services/api/src/modules/deliveries/deliveries.service.spec.ts
+++ b/services/api/src/modules/deliveries/deliveries.service.spec.ts
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it, mock } from 'node:test';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { DeliveryStatus } from '@local-office/db';
+
+import { DeliveriesService } from './deliveries.service';
+import type { CreateDeliveryDto } from './dto/create-delivery.dto';
+import type { QuoteDeliveryDto } from './dto/quote-delivery.dto';
+
+describe('DeliveriesService', () => {
+  const batchId = 'batch-123';
+  let prisma: any;
+  let queue: any;
+  let adapters: any;
+  let service: DeliveriesService;
+
+  beforeEach(() => {
+    prisma = {
+      batch: {
+        findUnique: mock.fn()
+      },
+      deliveryJob: {
+        upsert: mock.fn(),
+        findUnique: mock.fn(),
+        update: mock.fn()
+      }
+    };
+
+    queue = {
+      add: mock.fn()
+    };
+
+    adapters = {
+      dispatch: {
+        quote: mock.fn(),
+        create: mock.fn(),
+        cancel: mock.fn()
+      }
+    };
+
+    service = new DeliveriesService(prisma as any, adapters as any, queue as any);
+  });
+
+  describe('quote', () => {
+    const dto: QuoteDeliveryDto = {
+      adapter: 'dispatch',
+      pickupAddress: '123 Warehouse Ave',
+      dropoffAddress: '500 Office Blvd',
+      readyAt: '2024-01-01T12:00:00Z',
+      reference: 'batch-123'
+    };
+
+    it('delegates to the adapter after ensuring the batch exists', async () => {
+      prisma.batch.findUnique.mock.mockResolvedValue({ id: batchId });
+      adapters.dispatch.quote.mock.mockResolvedValue({ fee: 12.5, currency: 'USD', etaMinutes: 45 });
+
+      const result = await service.quote(batchId, dto);
+
+      assert.equal(prisma.batch.findUnique.mock.callCount(), 1);
+      assert.equal(adapters.dispatch.quote.mock.callCount(), 1);
+      assert.deepEqual(adapters.dispatch.quote.mock.calls[0].arguments[0], {
+        pickupAddress: dto.pickupAddress,
+        dropoffAddress: dto.dropoffAddress,
+        readyAt: dto.readyAt,
+        reference: dto.reference
+      });
+      assert.deepEqual(result, { fee: 12.5, currency: 'USD', etaMinutes: 45 });
+    });
+
+    it('throws when the batch is missing', async () => {
+      prisma.batch.findUnique.mock.mockResolvedValue(null);
+
+      await assert.rejects(() => service.quote(batchId, dto), NotFoundException);
+      assert.equal(adapters.dispatch.quote.mock.callCount(), 0);
+    });
+  });
+
+  describe('create', () => {
+    const dto: CreateDeliveryDto = {
+      adapter: 'dispatch',
+      pickupAddress: '123 Warehouse Ave',
+      dropoffAddress: '500 Office Blvd',
+      readyAt: '2024-01-01T12:00:00Z',
+      reference: 'batch-123',
+      contactEmail: 'ops@example.com',
+      contactPhone: '555-1234'
+    };
+
+    it('creates the delivery job record and enqueues an update job', async () => {
+      prisma.batch.findUnique.mock.mockResolvedValue({ id: batchId });
+      adapters.dispatch.create.mock.mockResolvedValue({ externalJobId: 'ext-1', trackingUrl: 'https://track/1' });
+      const record = {
+        id: 'delivery-1',
+        batchId,
+        adapter: 'dispatch',
+        externalJobId: 'ext-1',
+        trackingUrl: 'https://track/1',
+        status: DeliveryStatus.REQUESTED
+      };
+      prisma.deliveryJob.upsert.mock.mockResolvedValue(record);
+      queue.add.mock.mockResolvedValue({ id: 'queue-1' });
+
+      const result = await service.create(batchId, dto);
+
+      assert.equal(adapters.dispatch.create.mock.callCount(), 1);
+      assert.deepEqual(adapters.dispatch.create.mock.calls[0].arguments[0], {
+        pickupAddress: dto.pickupAddress,
+        dropoffAddress: dto.dropoffAddress,
+        readyAt: dto.readyAt,
+        reference: dto.reference,
+        contactEmail: dto.contactEmail,
+        contactPhone: dto.contactPhone
+      });
+
+      assert.equal(prisma.deliveryJob.upsert.mock.callCount(), 1);
+      const upsertArgs = prisma.deliveryJob.upsert.mock.calls[0].arguments[0];
+      assert.equal(upsertArgs.where.batchId, batchId);
+      assert.equal(upsertArgs.create.adapter, dto.adapter);
+      assert.equal(upsertArgs.create.externalJobId, 'ext-1');
+      assert.equal(upsertArgs.create.trackingUrl, 'https://track/1');
+      assert.equal(upsertArgs.create.status, DeliveryStatus.REQUESTED);
+      assert.equal(upsertArgs.update.status, DeliveryStatus.REQUESTED);
+
+      assert.equal(queue.add.mock.callCount(), 1);
+      const queueArgs = queue.add.mock.calls[0].arguments;
+      assert.equal(queueArgs[0], 'delivery-update');
+      assert.deepEqual(queueArgs[1], {
+        provider: dto.adapter,
+        externalJobId: 'ext-1',
+        status: 'requested',
+        trackingUrl: 'https://track/1',
+        rawPayload: { source: 'api.deliveries.create', batchId }
+      });
+      assert.equal(queueArgs[2]?.jobId, 'delivery:ext-1');
+
+      assert.deepEqual(result, record);
+    });
+
+    it('throws when the adapter result is missing the external job id', async () => {
+      prisma.batch.findUnique.mock.mockResolvedValue({ id: batchId });
+      adapters.dispatch.create.mock.mockResolvedValue({ externalJobId: '', trackingUrl: undefined });
+
+      await assert.rejects(() => service.create(batchId, dto), BadRequestException);
+      assert.equal(prisma.deliveryJob.upsert.mock.callCount(), 0);
+    });
+
+    it('throws when the adapter is not registered', async () => {
+      prisma.batch.findUnique.mock.mockResolvedValue({ id: batchId });
+
+      await assert.rejects(
+        () => service.create(batchId, { ...dto, adapter: 'unknown' }),
+        BadRequestException
+      );
+    });
+  });
+
+  describe('cancel', () => {
+    it('cancels the delivery job, updates status, and enqueues a follow-up', async () => {
+      const deliveryJob = {
+        id: 'delivery-1',
+        batchId,
+        adapter: 'dispatch',
+        externalJobId: 'ext-1',
+        status: DeliveryStatus.REQUESTED
+      };
+      prisma.deliveryJob.findUnique.mock.mockResolvedValue(deliveryJob);
+      prisma.deliveryJob.update.mock.mockImplementation(async ({ data }: any) => ({ ...deliveryJob, ...data }));
+      queue.add.mock.mockResolvedValue({ id: 'queue-2' });
+
+      const result = await service.cancel(batchId);
+
+      assert.equal(adapters.dispatch.cancel.mock.callCount(), 1);
+      assert.equal(adapters.dispatch.cancel.mock.calls[0].arguments[0], 'ext-1');
+
+      assert.equal(prisma.deliveryJob.update.mock.callCount(), 1);
+      const updateArgs = prisma.deliveryJob.update.mock.calls[0].arguments[0];
+      assert.equal(updateArgs.where.id, deliveryJob.id);
+      assert.equal(updateArgs.data.status, DeliveryStatus.CANCELED);
+      assert.ok(updateArgs.data.canceledAt instanceof Date);
+
+      assert.equal(queue.add.mock.callCount(), 1);
+      const queueArgs = queue.add.mock.calls[0].arguments;
+      assert.equal(queueArgs[0], 'delivery-update');
+      assert.equal(queueArgs[1].provider, 'dispatch');
+      assert.equal(queueArgs[1].externalJobId, 'ext-1');
+      assert.equal(queueArgs[1].status, 'canceled');
+      assert.equal(queueArgs[2]?.jobId, 'delivery:ext-1:cancel');
+
+      assert.equal(result.status, DeliveryStatus.CANCELED);
+    });
+
+    it('throws when the delivery job is missing', async () => {
+      prisma.deliveryJob.findUnique.mock.mockResolvedValue(null);
+
+      await assert.rejects(() => service.cancel(batchId), NotFoundException);
+    });
+
+    it('throws when the delivery job lacks an external identifier', async () => {
+      prisma.deliveryJob.findUnique.mock.mockResolvedValue({
+        id: 'delivery-1',
+        batchId,
+        adapter: 'dispatch',
+        externalJobId: null
+      });
+
+      await assert.rejects(() => service.cancel(batchId), BadRequestException);
+      assert.equal(adapters.dispatch.cancel.mock.callCount(), 0);
+    });
+  });
+});

--- a/services/api/src/modules/deliveries/deliveries.service.ts
+++ b/services/api/src/modules/deliveries/deliveries.service.ts
@@ -1,0 +1,164 @@
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import type {
+  AdapterRegistry,
+  CourierAdapter,
+  CreateJobRequest,
+  QuoteRequest
+} from '@local-office/dispatcher';
+import { DeliveryStatus } from '@local-office/db';
+import type { Queue } from 'bullmq';
+
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  DELIVERY_ADAPTERS,
+  DELIVERY_UPDATE_JOB_NAME,
+  DELIVERY_UPDATES_QUEUE
+} from './deliveries.constants';
+import type { CreateDeliveryDto } from './dto/create-delivery.dto';
+import type { QuoteDeliveryDto } from './dto/quote-delivery.dto';
+
+interface DeliveryUpdateJobData {
+  provider: string;
+  externalJobId: string;
+  status?: string;
+  timestamps?: Record<string, string | undefined>;
+  proof?: { url: string; type?: string };
+  trackingUrl?: string | null;
+  rawPayload: unknown;
+}
+
+@Injectable()
+export class DeliveriesService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(DELIVERY_ADAPTERS) private readonly adapters: AdapterRegistry,
+    @Inject(DELIVERY_UPDATES_QUEUE)
+    private readonly deliveryUpdatesQueue: Queue<DeliveryUpdateJobData>
+  ) {}
+
+  async quote(batchId: string, dto: QuoteDeliveryDto) {
+    await this.ensureBatchExists(batchId);
+    const adapter = this.getAdapter(dto.adapter);
+    return adapter.quote(this.toQuoteRequest(dto));
+  }
+
+  async create(batchId: string, dto: CreateDeliveryDto) {
+    await this.ensureBatchExists(batchId);
+    const adapter = this.getAdapter(dto.adapter);
+    const result = await adapter.create(this.toCreateRequest(dto));
+
+    if (!result.externalJobId) {
+      throw new BadRequestException('DELIVERY_JOB_ID_MISSING');
+    }
+
+    const trackingUrl = result.trackingUrl ?? null;
+
+    const deliveryJob = await this.prisma.deliveryJob.upsert({
+      where: { batchId },
+      create: {
+        batchId,
+        adapter: dto.adapter,
+        externalJobId: result.externalJobId,
+        trackingUrl,
+        status: DeliveryStatus.REQUESTED
+      },
+      update: {
+        adapter: dto.adapter,
+        externalJobId: result.externalJobId,
+        trackingUrl,
+        status: DeliveryStatus.REQUESTED
+      }
+    });
+
+    await this.deliveryUpdatesQueue.add(
+      DELIVERY_UPDATE_JOB_NAME,
+      {
+        provider: dto.adapter,
+        externalJobId: result.externalJobId,
+        status: 'requested',
+        trackingUrl,
+        rawPayload: { source: 'api.deliveries.create', batchId }
+      },
+      {
+        jobId: `delivery:${result.externalJobId}`,
+        removeOnComplete: true,
+        removeOnFail: 100
+      }
+    );
+
+    return deliveryJob;
+  }
+
+  async cancel(batchId: string) {
+    const deliveryJob = await this.prisma.deliveryJob.findUnique({ where: { batchId } });
+
+    if (!deliveryJob) {
+      throw new NotFoundException('Delivery job not found');
+    }
+
+    if (!deliveryJob.externalJobId) {
+      throw new BadRequestException('DELIVERY_JOB_EXTERNAL_ID_MISSING');
+    }
+
+    const adapter = this.getAdapter(deliveryJob.adapter);
+    await adapter.cancel(deliveryJob.externalJobId);
+
+    const updated = await this.prisma.deliveryJob.update({
+      where: { id: deliveryJob.id },
+      data: {
+        status: DeliveryStatus.CANCELED,
+        canceledAt: new Date()
+      }
+    });
+
+    await this.deliveryUpdatesQueue.add(
+      DELIVERY_UPDATE_JOB_NAME,
+      {
+        provider: deliveryJob.adapter,
+        externalJobId: deliveryJob.externalJobId,
+        status: 'canceled',
+        rawPayload: { source: 'api.deliveries.cancel', batchId }
+      },
+      {
+        jobId: `delivery:${deliveryJob.externalJobId}:cancel`,
+        removeOnComplete: true,
+        removeOnFail: 100
+      }
+    );
+
+    return updated;
+  }
+
+  private getAdapter(name: string): CourierAdapter {
+    const adapter = this.adapters?.[name];
+    if (!adapter) {
+      throw new BadRequestException(`Unsupported delivery adapter: ${name}`);
+    }
+
+    return adapter;
+  }
+
+  private async ensureBatchExists(batchId: string) {
+    const batch = await this.prisma.batch.findUnique({ where: { id: batchId }, select: { id: true } });
+    if (!batch) {
+      throw new NotFoundException('Batch not found');
+    }
+  }
+
+  private toQuoteRequest(dto: QuoteDeliveryDto): QuoteRequest {
+    return {
+      pickupAddress: dto.pickupAddress,
+      dropoffAddress: dto.dropoffAddress,
+      readyAt: dto.readyAt,
+      reference: dto.reference
+    };
+  }
+
+  private toCreateRequest(dto: CreateDeliveryDto): CreateJobRequest {
+    return {
+      ...this.toQuoteRequest(dto),
+      contactEmail: dto.contactEmail,
+      contactPhone: dto.contactPhone
+    };
+  }
+}

--- a/services/api/src/modules/deliveries/dto/create-delivery.dto.ts
+++ b/services/api/src/modules/deliveries/dto/create-delivery.dto.ts
@@ -1,0 +1,13 @@
+import { IsOptional, IsString } from 'class-validator';
+
+import { QuoteDeliveryDto } from './quote-delivery.dto';
+
+export class CreateDeliveryDto extends QuoteDeliveryDto {
+  @IsOptional()
+  @IsString()
+  contactEmail?: string;
+
+  @IsOptional()
+  @IsString()
+  contactPhone?: string;
+}

--- a/services/api/src/modules/deliveries/dto/quote-delivery.dto.ts
+++ b/services/api/src/modules/deliveries/dto/quote-delivery.dto.ts
@@ -1,0 +1,18 @@
+import { IsISO8601, IsString } from 'class-validator';
+
+export class QuoteDeliveryDto {
+  @IsString()
+  adapter!: string;
+
+  @IsString()
+  pickupAddress!: string;
+
+  @IsString()
+  dropoffAddress!: string;
+
+  @IsISO8601()
+  readyAt!: string;
+
+  @IsString()
+  reference!: string;
+}

--- a/services/api/test/stubs/@local-office/dispatcher.js
+++ b/services/api/test/stubs/@local-office/dispatcher.js
@@ -1,0 +1,27 @@
+class BaseAdapter {
+  async quote() {
+    throw new Error('Not implemented in test stub');
+  }
+
+  async create() {
+    throw new Error('Not implemented in test stub');
+  }
+
+  async cancel() {
+    throw new Error('Not implemented in test stub');
+  }
+
+  async parseWebhook() {
+    throw new Error('Not implemented in test stub');
+  }
+}
+
+class DispatchAdapter extends BaseAdapter {}
+class UberDirectAdapter extends BaseAdapter {}
+class OloAdapter extends BaseAdapter {}
+
+module.exports = {
+  DispatchAdapter,
+  UberDirectAdapter,
+  OloAdapter
+};

--- a/services/api/test/stubs/@local-office/dispatcher.ts
+++ b/services/api/test/stubs/@local-office/dispatcher.ts
@@ -1,0 +1,62 @@
+export interface QuoteRequest {
+  pickupAddress: string;
+  dropoffAddress: string;
+  readyAt: string;
+  reference: string;
+}
+
+export interface QuoteResponse {
+  fee: number;
+  currency: string;
+  etaMinutes: number;
+}
+
+export interface CreateJobRequest extends QuoteRequest {
+  contactEmail?: string;
+  contactPhone?: string;
+}
+
+export interface CreateJobResponse {
+  externalJobId: string;
+  trackingUrl?: string;
+}
+
+export interface DeliveryUpdate {
+  provider: string;
+  externalJobId: string;
+  status: string;
+  timestamps: Record<string, string | undefined>;
+  proof?: { url: string; type?: string };
+  rawPayload: unknown;
+}
+
+export interface CourierAdapter {
+  quote(req: QuoteRequest): Promise<QuoteResponse>;
+  create(job: CreateJobRequest): Promise<CreateJobResponse>;
+  cancel(externalJobId: string): Promise<void>;
+  parseWebhook?(req: unknown): Promise<DeliveryUpdate>;
+}
+
+export type AdapterRegistry = Record<string, CourierAdapter>;
+
+class BaseAdapter implements CourierAdapter {
+  async quote(): Promise<QuoteResponse> {
+    throw new Error('Not implemented in test stub');
+  }
+
+  async create(): Promise<CreateJobResponse> {
+    throw new Error('Not implemented in test stub');
+  }
+
+  async cancel(): Promise<void> {
+    throw new Error('Not implemented in test stub');
+  }
+
+  async parseWebhook(): Promise<DeliveryUpdate> {
+    throw new Error('Not implemented in test stub');
+  }
+}
+
+export class DispatchAdapter extends BaseAdapter {}
+export class UberDirectAdapter extends BaseAdapter {}
+export class OloAdapter extends BaseAdapter {}

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -18,7 +18,9 @@
       "@local-office/billing": ["../billing/src"],
       "@local-office/billing/*": ["../billing/src/*"],
       "@local-office/worker": ["../worker/src"],
-      "@local-office/worker/*": ["../worker/src/*"]
+      "@local-office/worker/*": ["../worker/src/*"],
+      "@local-office/dispatcher": ["../dispatcher/src"],
+      "@local-office/dispatcher/*": ["../dispatcher/src/*"]
     },
     "incremental": true,
     "strictNullChecks": true,

--- a/services/api/tsconfig.spec.json
+++ b/services/api/tsconfig.spec.json
@@ -10,6 +10,8 @@
       "@local-office/billing/*": ["../billing/src/*"],
       "@local-office/worker": ["./test/stubs/local-office-worker.ts"],
       "@local-office/worker/*": ["./test/stubs/local-office-worker.ts"],
+      "@local-office/dispatcher": ["./test/stubs/@local-office/dispatcher.ts"],
+      "@local-office/dispatcher/*": ["./test/stubs/@local-office/dispatcher.ts"],
       "@nestjs/common": ["./test/stubs/nestjs-common.ts"]
     }
   }


### PR DESCRIPTION
## Summary
- add a deliveries NestJS module that surfaces quote, create, and cancel endpoints backed by dispatcher adapters
- persist delivery job metadata in Prisma and publish delivery update jobs when creating or canceling
- add unit coverage for deliveries service with mocked adapters, Prisma, and queue interactions plus test stubs for dispatcher

## Testing
- `pnpm --filter @local-office/api test` *(fails: workspace contains invalid packages/contracts/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e191544d7c8321a10f925b494afaa6