### PR TITLE
feat(worker): integrate billing service for invoices

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -82,6 +82,7 @@ model Org {
   slug            String          @unique
   billingEmail    String?
   loyaltyTier     LoyaltyTier     @default(BRONZE)
+  billingConfig   OrgBillingConfig?
   sites           Site[]
   users           User[]
   programs        Program[]
@@ -307,10 +308,24 @@ model Invoice {
   total          Decimal        @db.Numeric(10, 2)
   externalId     String?
   status         String         @default("draft")
+  externalUrl    String?
+  rawResponse    Json?
   lines          InvoiceLine[]
   payments       Payment[]
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
+}
+
+model OrgBillingConfig {
+  id               String   @id @default(cuid())
+  org              Org      @relation(fields: [orgId], references: [id])
+  orgId            String   @unique
+  squareCustomerId String
+  squareLocationId String
+  currency         String   @default("USD")
+  netTermsDays     Int      @default(14)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
 }
 
 model InvoiceLine {

--- a/services/worker/package.json
+++ b/services/worker/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@local-office/billing": "workspace:^",
     "@local-office/db": "workspace:^",
     "@local-office/lib": "workspace:^",
     "@local-office/labeler": "workspace:^",

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -2,6 +2,7 @@ import { Queue, Worker, QueueScheduler, type JobsOptions, type QueueOptions } fr
 import { prisma } from '@local-office/db';
 import { createIdempotencyKey } from '@local-office/lib';
 
+import { BillingService } from '@local-office/billing';
 import { createBatcherJob } from './jobs/batcher';
 import { createInvoiceJob } from './jobs/invoice';
 import { createLabelJob } from './jobs/labels';
@@ -128,6 +129,7 @@ void schedulers;
 
 const storage = createObjectStorage();
 const notifier = createDefaultNotificationClient();
+const billing = new BillingService();
 
 const workers = [
   new Worker(
@@ -147,7 +149,7 @@ const workers = [
   ),
   new Worker(
     queues.invoice.name,
-    withJobLogging('invoice', createInvoiceJob(prisma)),
+    withJobLogging('invoice', createInvoiceJob(prisma, billing)),
     { ...baseConnection, concurrency: queueConfigurations.invoice.concurrency }
   ),
   new Worker(

--- a/services/worker/src/jobs/invoice.ts
+++ b/services/worker/src/jobs/invoice.ts
@@ -1,6 +1,7 @@
 import type { Job } from 'bullmq';
 import type { PrismaClient } from '@local-office/db';
 import { BatchStatus, InvoicePeriod, Prisma } from '@local-office/db';
+import type { BillingService } from '@local-office/billing';
 
 export interface InvoiceJobData {
   orgId?: string;
@@ -42,9 +43,26 @@ function resolvePeriodRange(period: InvoicePeriod, start?: string, end?: string)
   return { start: startOfPrevWeek, end: endOfPrevWeek };
 }
 
-export function createInvoiceJob(prisma: PrismaClient) {
+function formatDateOnly(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function describePeriod(period: InvoicePeriod): string {
+  return period === InvoicePeriod.MONTH ? 'Monthly' : 'Weekly';
+}
+
+export function createInvoiceJob(prisma: PrismaClient, billing: BillingService) {
   async function processInvoice(orgId: string, period: InvoicePeriod, start: Date, end: Date): Promise<InvoiceSummary> {
     return prisma.$transaction(async (tx) => {
+      const billingConfig = await tx.orgBillingConfig.findUnique({
+        where: { orgId },
+        include: { org: true }
+      });
+
+      if (!billingConfig) {
+        throw new Error(`Missing billing configuration for org ${orgId}`);
+      }
+
       const batches = await tx.batch.findMany({
         where: {
           orgId,
@@ -112,10 +130,12 @@ export function createInvoiceJob(prisma: PrismaClient) {
               deliveryTotal: totals.deliveryTotal,
               tipsTotal: totals.tipsTotal,
               total: totals.total
-            }
-          });
+          }
+        });
 
       await tx.invoiceLine.deleteMany({ where: { invoiceId: invoice.id } });
+
+      const lineItems = [] as { name: string; quantity: number; amount: number }[];
 
       for (const batch of batches) {
         const orderTotal = batch.orders.reduce((acc, order) => acc.plus(order.total), ZERO);
@@ -133,9 +153,38 @@ export function createInvoiceJob(prisma: PrismaClient) {
             total: lineTotal
           }
         });
+
+        lineItems.push({ name: `Batch ${batch.id}`, quantity: 1, amount: Number(lineTotal.toString()) });
       }
 
-      return { orgId, invoiceId: invoice.id, batchCount: batches.length, total: invoice.total.toString() };
+      const dueDate = new Date(end);
+      dueDate.setUTCDate(dueDate.getUTCDate() + (billingConfig.netTermsDays ?? 0));
+
+      const invoiceResponse = await billing.createInvoice({
+        orgId,
+        locationId: billingConfig.squareLocationId,
+        customerId: billingConfig.squareCustomerId,
+        dueDate: formatDateOnly(dueDate),
+        currency: billingConfig.currency ?? 'USD',
+        lineItems,
+        title: `${describePeriod(period)} Invoice - ${billingConfig.org.name}`,
+        description: `Services rendered ${formatDateOnly(start)} to ${formatDateOnly(end)}`,
+        idempotencyKey: `invoice_${invoice.id}`,
+        period
+      });
+
+      const updatedInvoice = await tx.invoice.update({
+        where: { id: invoice.id },
+        data: {
+          externalId: invoiceResponse.id,
+          status: invoiceResponse.status,
+          total: invoiceResponse.totalAmount != null ? new Prisma.Decimal(invoiceResponse.totalAmount) : invoice.total,
+          externalUrl: invoiceResponse.publicUrl ?? undefined,
+          rawResponse: invoiceResponse.rawResponse as any
+        }
+      });
+
+      return { orgId, invoiceId: updatedInvoice.id, batchCount: batches.length, total: updatedInvoice.total.toString() };
     });
   }
 

--- a/services/worker/tests/invoice.job.test.ts
+++ b/services/worker/tests/invoice.job.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Job } from 'bullmq';
+import { BatchStatus, InvoicePeriod, Prisma } from '@local-office/db';
+
+import { createInvoiceJob, type InvoiceJobData } from '../src/jobs/invoice';
+
+describe('invoice job', () => {
+  function createPrismaStub() {
+    const start = new Date('2024-09-02T00:00:00.000Z');
+    const end = new Date('2024-09-08T23:59:59.999Z');
+
+    const state = {
+      invoiceSequence: 0,
+      invoices: [] as any[],
+      invoiceLines: [] as any[],
+      batches: [
+        {
+          id: 'batch-1',
+          orgId: 'org-1',
+          status: BatchStatus.LOCKED,
+          deliveryFee: new Prisma.Decimal(20),
+          gratuity: new Prisma.Decimal(10),
+          programSlot: { serviceDate: new Date('2024-09-04T12:00:00.000Z') },
+          orders: [
+            { id: 'order-1', total: new Prisma.Decimal(150) }
+          ]
+        }
+      ],
+      billingConfig: {
+        orgId: 'org-1',
+        squareCustomerId: 'cust-1',
+        squareLocationId: 'loc-1',
+        currency: 'USD',
+        netTermsDays: 7,
+        org: { id: 'org-1', name: 'Org One' }
+      },
+      range: { start, end }
+    };
+
+    const prisma = {
+      batch: {
+        findMany: vi.fn(async () => state.batches)
+      },
+      invoice: {
+        findFirst: vi.fn(async () => null),
+        create: vi.fn(async ({ data }: any) => {
+          const id = `inv-${++state.invoiceSequence}`;
+          const invoice = {
+            ...data,
+            id,
+            externalId: null as string | null,
+            status: data.status ?? 'draft',
+            externalUrl: null as string | null,
+            rawResponse: null as unknown,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          };
+          state.invoices.push(invoice);
+          return { ...invoice };
+        }),
+        update: vi.fn(async ({ where, data }: any) => {
+          const invoice = state.invoices.find((entry) => entry.id === where.id);
+          if (!invoice) {
+            throw new Error('Invoice not found');
+          }
+          Object.assign(invoice, data, { updatedAt: new Date() });
+          return { ...invoice };
+        })
+      },
+      invoiceLine: {
+        deleteMany: vi.fn(async ({ where }: any) => {
+          state.invoiceLines = state.invoiceLines.filter((line) => line.invoiceId !== where.invoiceId);
+        }),
+        create: vi.fn(async ({ data }: any) => {
+          state.invoiceLines.push({ ...data });
+          return { ...data };
+        })
+      },
+      orgBillingConfig: {
+        findUnique: vi.fn(async ({ where }: any) => {
+          return where.orgId === state.billingConfig.orgId ? { ...state.billingConfig } : null;
+        })
+      },
+      $transaction: async (fn: any) => {
+        const snapshot = {
+          invoiceSequence: state.invoiceSequence,
+          invoices: state.invoices.map((invoice) => ({ ...invoice })),
+          invoiceLines: state.invoiceLines.map((line) => ({ ...line }))
+        };
+        try {
+          return await fn(prisma);
+        } catch (error) {
+          state.invoiceSequence = snapshot.invoiceSequence;
+          state.invoices = snapshot.invoices;
+          state.invoiceLines = snapshot.invoiceLines;
+          throw error;
+        }
+      }
+    } as any;
+
+    return { prisma, state };
+  }
+
+  it('calls billing service and stores Square metadata', async () => {
+    const { prisma, state } = createPrismaStub();
+
+    const billing = {
+      createInvoice: vi.fn(async () => ({
+        id: 'sq-invoice-1',
+        status: 'DRAFT',
+        totalAmount: 180,
+        publicUrl: 'https://square.test/invoices/sq-invoice-1',
+        rawResponse: { id: 'sq-invoice-1', status: 'DRAFT' }
+      }))
+    } as any;
+
+    const handler = createInvoiceJob(prisma, billing);
+
+    const job: Job<InvoiceJobData> = {
+      name: 'closeout',
+      id: 'job-1',
+      data: {
+        orgId: 'org-1',
+        period: InvoicePeriod.WEEK,
+        periodStart: state.range.start.toISOString(),
+        periodEnd: state.range.end.toISOString()
+      }
+    } as Job<InvoiceJobData>;
+
+    const result = await handler(job);
+
+    expect(result).toEqual([
+      {
+        orgId: 'org-1',
+        invoiceId: 'inv-1',
+        batchCount: 1,
+        total: '180'
+      }
+    ]);
+
+    expect(billing.createInvoice).toHaveBeenCalledTimes(1);
+    expect(billing.createInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: 'org-1',
+        customerId: 'cust-1',
+        locationId: 'loc-1',
+        dueDate: '2024-09-15',
+        idempotencyKey: 'invoice_inv-1',
+        period: InvoicePeriod.WEEK,
+        lineItems: [
+          {
+            name: 'Batch batch-1',
+            quantity: 1,
+            amount: 180
+          }
+        ]
+      })
+    );
+
+    const stored = state.invoices.find((invoice) => invoice.id === 'inv-1');
+    expect(stored).toMatchObject({
+      externalId: 'sq-invoice-1',
+      status: 'DRAFT',
+      externalUrl: 'https://square.test/invoices/sq-invoice-1',
+      rawResponse: { id: 'sq-invoice-1', status: 'DRAFT' }
+    });
+  });
+
+  it('bubbles up billing failures', async () => {
+    const { prisma, state } = createPrismaStub();
+
+    const billingError = new Error('Square unavailable');
+    const billing = {
+      createInvoice: vi.fn(async () => {
+        throw billingError;
+      })
+    } as any;
+
+    const handler = createInvoiceJob(prisma, billing);
+
+    const job: Job<InvoiceJobData> = {
+      name: 'closeout',
+      id: 'job-2',
+      data: {
+        orgId: 'org-1',
+        period: InvoicePeriod.WEEK,
+        periodStart: state.range.start.toISOString(),
+        periodEnd: state.range.end.toISOString()
+      }
+    } as Job<InvoiceJobData>;
+
+    await expect(handler(job)).rejects.toThrow(billingError);
+    expect(billing.createInvoice).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/worker/tests/stubs/db.ts
+++ b/services/worker/tests/stubs/db.ts
@@ -39,6 +39,10 @@ export const Prisma = {
   Decimal
 };
 
+export namespace Prisma {
+  export type InputJsonValue = unknown;
+}
+
 export class PrismaClient {}
 
 export const prisma = {} as unknown;


### PR DESCRIPTION
## Summary
- add billing configuration model and invoice metadata fields to the Prisma schema so Square identifiers and payloads can be stored
- invoke the billing service during invoice aggregation to create Square invoices and persist the returned details
- instantiate the billing service in the worker and cover the new flow with tests that stub the billing client

## Testing
- pnpm --filter @local-office/worker test *(fails: packages/contracts/package.json has invalid JSON)*
- npx --yes vitest@2.1.4 run *(fails: vitest/config could not be resolved in the transient npx install)*

------
https://chatgpt.com/codex/tasks/task_e_68e191529b4c8321aeb070d7f1e46e4a