### PR TITLE
fix: update worker lockfile deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
       '@local-office/db':
         specifier: workspace:^
         version: link:../../packages/db
+      '@local-office/dispatcher':
+        specifier: workspace:^
+        version: link:../dispatcher
       '@local-office/lib':
         specifier: workspace:^
         version: link:../../packages/lib
@@ -604,6 +607,9 @@ importers:
 
   services/worker:
     dependencies:
+      '@local-office/billing':
+        specifier: workspace:^
+        version: link:../billing
       '@local-office/db':
         specifier: workspace:^
         version: link:../../packages/db


### PR DESCRIPTION
## Summary
- update pnpm lockfile to include the @local-office/billing workspace dependency for the worker service

## Testing
- pnpm install

------
https://chatgpt.com/codex/tasks/task_e_68e19fef13248321bc36d7fb23828614