### PR TITLE
Fix missing Calculator icon import

### DIFF
--- a/src/partners/gallant/App.jsx
+++ b/src/partners/gallant/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Calendar, Plus, DollarSign, TrendingUp, ShoppingCart, Save, X, ChevronLeft, ChevronRight, Trash2, FileText } from 'lucide-react';
+import { Calendar, Plus, DollarSign, TrendingUp, ShoppingCart, Save, X, ChevronLeft, ChevronRight, Trash2, FileText, Calculator } from 'lucide-react';
 import { db, firebaseProjectId } from '../../firebaseConfig';
 import Notepad from './Notepad';
 // Auth removed: tools are now public-access


### PR DESCRIPTION
## Summary
- add the missing Calculator icon import for the Gallant partner app navigation to prevent runtime errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1c82f10508321beb2e8ff885affe5