### PR TITLE
Implement Square Web Payments for Paikka checkout

### DIFF
--- a/api/paikka/pay.js
+++ b/api/paikka/pay.js
@@ -1,0 +1,170 @@
+const { Client, Environment } = require('square');
+
+const { MENU_LOOKUP, formatCurrency } = require('../../src/features/paikka/menu');
+
+const ACCESS_TOKEN = process.env.SQUARE_ACCESS_TOKEN;
+const LOCATION_ID = process.env.SQUARE_LOCATION_ID;
+const ENV_NAME = (process.env.SQUARE_ENVIRONMENT || 'production').toLowerCase();
+
+let squareClient = null;
+
+try {
+  if (ACCESS_TOKEN) {
+    const env = ENV_NAME === 'sandbox' ? Environment.Sandbox : Environment.Production;
+    squareClient = new Client({ accessToken: ACCESS_TOKEN, environment: env });
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.log('[paikka.pay] Square client initialized', {
+        env: env === Environment.Sandbox ? 'Sandbox' : 'Production',
+        hasLocation: Boolean(LOCATION_ID),
+        tokenTail: ACCESS_TOKEN.slice(-4),
+      });
+    }
+  }
+} catch (error) {
+  squareClient = null;
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error('[paikka.pay] Failed to initialize Square client', error);
+  }
+}
+
+const parseItems = (items) => {
+  if (!Array.isArray(items) || !items.length) {
+    throw new Error('At least one item is required.');
+  }
+
+  return items.map((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error('Invalid item payload.');
+    }
+    const sku = entry.sku;
+    const qty = Number(entry.qty);
+    if (typeof sku !== 'string' || !MENU_LOOKUP.has(sku)) {
+      throw new Error('Unsupported SKU.');
+    }
+    if (!Number.isInteger(qty) || qty <= 0) {
+      throw new Error('Invalid quantity.');
+    }
+    return { sku, qty };
+  });
+};
+
+const sanitizeCustomer = (customer = {}) => {
+  const firstName = typeof customer.firstName === 'string' ? customer.firstName.trim() : '';
+  const lastName = typeof customer.lastName === 'string' ? customer.lastName.trim() : '';
+  const email = typeof customer.email === 'string' ? customer.email.trim() : '';
+
+  if (!firstName) {
+    throw new Error('First name is required.');
+  }
+  if (!email || !/.+@.+/.test(email)) {
+    throw new Error('A valid email is required.');
+  }
+
+  return {
+    firstName,
+    lastName: lastName || undefined,
+    email,
+  };
+};
+
+const computeTotals = (parsedItems, tipCentsRaw = 0) => {
+  const subtotal = parsedItems.reduce((sum, item) => {
+    const menuItem = MENU_LOOKUP.get(item.sku);
+    if (!menuItem) {
+      throw new Error('Unsupported SKU.');
+    }
+    return sum + menuItem.presalePriceCents * item.qty;
+  }, 0);
+
+  if (subtotal <= 0) {
+    throw new Error('Cart is empty.');
+  }
+
+  const tipCents = Number.isFinite(Number(tipCentsRaw)) && Number(tipCentsRaw) > 0 ? Math.round(Number(tipCentsRaw)) : 0;
+  return { subtotal, tipCents, total: subtotal + tipCents };
+};
+
+const buildPaymentNote = (items, tipCents) => {
+  const parts = items.map(({ sku, qty }) => {
+    const menu = MENU_LOOKUP.get(sku);
+    if (!menu) return `${sku} x${qty}`;
+    return `${menu.summaryTitle || menu.squareName || menu.title} x${qty}`;
+  });
+  if (tipCents > 0) {
+    parts.push(`Tip ${formatCurrency(tipCents)}`);
+  }
+  return parts.join(' | ').slice(0, 500);
+};
+
+module.exports = async (req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    return res.status(204).end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (!squareClient) {
+    return res.status(500).json({ error: 'Square is not configured' });
+  }
+
+  try {
+    const { items, customer, tipCents: tipCentsRaw, token } = req.body || {};
+    if (!token || typeof token !== 'string') {
+      throw new Error('Missing payment token.');
+    }
+
+    const parsedItems = parseItems(items);
+    const normalizedCustomer = sanitizeCustomer(customer);
+    const totals = computeTotals(parsedItems, tipCentsRaw);
+
+    const idempotencyKey = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    const paymentsApi = squareClient.paymentsApi;
+    const paymentBody = {
+      sourceId: token,
+      idempotencyKey,
+      locationId: LOCATION_ID,
+      amountMoney: { amount: totals.total, currency: 'USD' },
+      autocomplete: true,
+      buyerEmailAddress: normalizedCustomer.email,
+      note: buildPaymentNote(parsedItems, totals.tipCents),
+      metadata: {
+        first_name: normalizedCustomer.firstName.slice(0, 50),
+        last_name: (normalizedCustomer.lastName || '').slice(0, 50),
+      },
+    };
+
+    if (totals.tipCents > 0) {
+      paymentBody.tipMoney = { amount: totals.tipCents, currency: 'USD' };
+    }
+
+    const response = await paymentsApi.createPayment(paymentBody);
+    const paymentId = response?.result?.payment?.id;
+
+    if (!paymentId) {
+      throw new Error('Payment failed.');
+    }
+
+    return res.status(200).json({ ok: true, paymentId });
+  } catch (error) {
+    const squareErrors = error?.errors;
+    if (Array.isArray(squareErrors) && squareErrors.length > 0) {
+      const summarized = squareErrors.slice(0, 3).map((entry) => ({ code: entry.code, detail: entry.detail }));
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('[paikka.pay] Square error', summarized);
+      }
+      return res.status(502).json({ error: JSON.stringify(summarized) });
+    }
+
+    const message = error instanceof Error ? error.message : 'Checkout failed. Please try again.';
+    return res.status(400).json({ error: message });
+  }
+};

--- a/apps/api/src/orders.ts
+++ b/apps/api/src/orders.ts
@@ -6,12 +6,22 @@ import { getActiveKey, getKeyByKid } from "./keys.js";
 const itemsMap = {
   SMOKED_CHICKEN: {
     sku: "SMOKED_CHICKEN" as const,
-    name: "Smoked chicken on sourdough focaccia",
+    name: "Smoked chicken sandwich",
+    unit: 1400
+  },
+  SMOKED_CHICKEN_DF: {
+    sku: "SMOKED_CHICKEN_DF" as const,
+    name: "Smoked chicken sandwich (dairy free)",
     unit: 1400
   },
   PUMPKIN_ROMESCO: {
     sku: "PUMPKIN_ROMESCO" as const,
-    name: "Pumpkin & romesco on sourdough focaccia",
+    name: "Marinated squash sandwich",
+    unit: 1300
+  },
+  PUMPKIN_ROMESCO_DF: {
+    sku: "PUMPKIN_ROMESCO_DF" as const,
+    name: "Marinated squash sandwich (dairy free)",
     unit: 1300
   }
 };

--- a/local-office/apps/web/app/api/paikka/checkout/route.ts
+++ b/local-office/apps/web/app/api/paikka/checkout/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { MENU_LOOKUP } from '../../../paikka/menu';
+import type { MenuItem } from '../../../paikka/menu';
 
 type CheckoutRequest = {
-  items: Array<{ sku: 'SMOKED_CHICKEN' | 'PUMPKIN_ROMESCO'; qty: number }>;
+  items: Array<{ sku: MenuItem['sku']; qty: number }>;
   customer: {
     firstName: string;
     lastName?: string;

--- a/local-office/apps/web/app/paikka/menu.ts
+++ b/local-office/apps/web/app/paikka/menu.ts
@@ -1,28 +1,66 @@
+type PaikkaSku = 'SMOKED_CHICKEN' | 'SMOKED_CHICKEN_DF' | 'PUMPKIN_ROMESCO' | 'PUMPKIN_ROMESCO_DF';
+
 export type MenuItem = {
-  sku: 'SMOKED_CHICKEN' | 'PUMPKIN_ROMESCO';
+  sku: PaikkaSku;
+  baseSku: 'SMOKED_CHICKEN' | 'PUMPKIN_ROMESCO';
   title: string;
+  summaryTitle?: string;
   description: string;
   presalePriceCents: number;
   regularPriceCents: number;
   squareName: string;
+  variantLabel: string;
+  isDairyFree: boolean;
 };
 
 export const MENU_ITEMS: MenuItem[] = [
   {
     sku: 'SMOKED_CHICKEN',
-    title: 'Smoked chicken',
-    description: 'Served on sourdough focaccia. 100% local ingredients.',
+    baseSku: 'SMOKED_CHICKEN',
+    title: 'Smoked chicken sandwich',
+    summaryTitle: 'Smoked chicken sandwich',
+    description: 'Roasted cabbage mostarda, apple and celery, colby cheese.',
     presalePriceCents: 1400,
     regularPriceCents: 1600,
-    squareName: 'Smoked chicken on sourdough focaccia'
+    squareName: 'Smoked chicken sandwich on sourdough focaccia',
+    variantLabel: 'Standard',
+    isDairyFree: false
+  },
+  {
+    sku: 'SMOKED_CHICKEN_DF',
+    baseSku: 'SMOKED_CHICKEN',
+    title: 'Smoked chicken sandwich',
+    summaryTitle: 'Smoked chicken sandwich (dairy free)',
+    description: 'Roasted cabbage mostarda, apple and celery. Dairy-free option served without cheese.',
+    presalePriceCents: 1400,
+    regularPriceCents: 1600,
+    squareName: 'Smoked chicken sandwich (dairy free) on sourdough focaccia',
+    variantLabel: 'Dairy free',
+    isDairyFree: true
   },
   {
     sku: 'PUMPKIN_ROMESCO',
-    title: 'Pumpkin & romesco',
-    description: 'Served on sourdough focaccia. 100% local ingredients.',
+    baseSku: 'PUMPKIN_ROMESCO',
+    title: 'Marinated squash sandwich',
+    summaryTitle: 'Marinated squash sandwich',
+    description: 'Romesco, spinach, gruyere.',
     presalePriceCents: 1300,
     regularPriceCents: 1500,
-    squareName: 'Pumpkin & romesco on sourdough focaccia'
+    squareName: 'Marinated squash sandwich on sourdough focaccia',
+    variantLabel: 'Standard',
+    isDairyFree: false
+  },
+  {
+    sku: 'PUMPKIN_ROMESCO_DF',
+    baseSku: 'PUMPKIN_ROMESCO',
+    title: 'Marinated squash sandwich',
+    summaryTitle: 'Marinated squash sandwich (dairy free)',
+    description: 'Romesco, spinach. Dairy-free option served without gruyere.',
+    presalePriceCents: 1300,
+    regularPriceCents: 1500,
+    squareName: 'Marinated squash sandwich (dairy free) on sourdough focaccia',
+    variantLabel: 'Dairy free',
+    isDairyFree: true
   }
 ];
 
@@ -31,3 +69,36 @@ export const MENU_LOOKUP = new Map(MENU_ITEMS.map((item) => [item.sku, item]));
 const currency = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
 
 export const formatCurrency = (cents: number) => currency.format(cents / 100);
+
+type MenuGroup = {
+  baseSku: MenuItem['baseSku'];
+  title: string;
+  description: string;
+  presalePriceCents: number;
+  regularPriceCents: number;
+  variants: MenuItem[];
+};
+
+const groupedMenuMap = MENU_ITEMS.reduce<Map<MenuItem['baseSku'], MenuGroup>>((map, item) => {
+  const key = item.baseSku;
+  if (!map.has(key)) {
+    map.set(key, {
+      baseSku: key,
+      title: item.title,
+      description: item.description,
+      presalePriceCents: item.presalePriceCents,
+      regularPriceCents: item.regularPriceCents,
+      variants: []
+    });
+  }
+  map.get(key)!.variants.push(item);
+  return map;
+}, new Map());
+
+export const GROUPED_MENU: MenuGroup[] = Array.from(groupedMenuMap.values()).map((entry) => ({
+  ...entry,
+  variants: entry.variants.slice().sort((a, b) => {
+    if (a.isDairyFree === b.isDairyFree) return 0;
+    return a.isDairyFree ? 1 : -1;
+  })
+}));

--- a/local-office/apps/web/app/paikka/success/page.tsx
+++ b/local-office/apps/web/app/paikka/success/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import type { Order } from '@local-effort/shared';
 
 import { formatCurrency, MENU_LOOKUP } from '../menu';
+import type { MenuItem } from '../menu';
 import { ResendEmailButton } from '../resend-email-button';
 
 type SearchParams = Record<string, string | string[] | undefined>;
@@ -12,7 +13,7 @@ type CheckoutState = {
   email: string;
   firstName: string;
   lastName?: string;
-  items: Array<{ sku: 'SMOKED_CHICKEN' | 'PUMPKIN_ROMESCO'; qty: number }>;
+  items: Array<{ sku: MenuItem['sku']; qty: number }>;
   tipCents?: number;
 };
 
@@ -43,7 +44,7 @@ const decodeState = (value: string): CheckoutState => {
         qty: Number(item.qty)
       }))
       .filter((item): item is { sku: CheckoutState['items'][number]['sku']; qty: number } =>
-        (item.sku === 'SMOKED_CHICKEN' || item.sku === 'PUMPKIN_ROMESCO') && Number.isFinite(item.qty) && item.qty > 0
+        MENU_LOOKUP.has(item.sku) && Number.isFinite(item.qty) && item.qty > 0
       ),
     tipCents: Number.isFinite(parsed.tipCents) && parsed.tipCents ? Number(parsed.tipCents) : 0
   };
@@ -173,10 +174,15 @@ export default async function SuccessPage({ searchParams }: { searchParams: Sear
                   const menu = MENU_LOOKUP.get(item.sku);
                   if (!menu) return null;
                   return (
-                    <li key={item.sku} className="flex justify-between">
-                      <span>
-                        {menu.title} × {item.qty}
-                      </span>
+                    <li key={item.sku} className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="space-y-0.5">
+                        <span className="font-medium text-slate-900">
+                          {menu.summaryTitle || menu.title} × {item.qty}
+                        </span>
+                        {menu.isDairyFree && (
+                          <span className="text-xs uppercase tracking-[0.2em] text-orange-600">Dairy free</span>
+                        )}
+                      </div>
                       <span>{formatCurrency(menu.presalePriceCents * item.qty)}</span>
                     </li>
                   );

--- a/src/features/paikka/PaikkaCheckout.jsx
+++ b/src/features/paikka/PaikkaCheckout.jsx
@@ -2,10 +2,12 @@ import React, { useMemo, useState } from 'react';
 import clsx from 'clsx';
 
 import { Button } from '../../components/ui/button';
-import { MENU_ITEMS, formatCurrency } from './menu';
-import { TIP_OPTIONS, isValidEmail } from './utils';
+import { GROUPED_MENU, MENU_ITEMS, formatCurrency } from './menu';
+import { TIP_OPTIONS, base64UrlEncode, isValidEmail } from './utils';
+import { useSquareCard } from '../../hooks/useSquareCard';
 
-const inputClassName = 'w-full rounded-md border border-neutral-300 px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-orange-200';
+const inputClassName =
+  'w-full rounded-md border border-neutral-300 px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-orange-200';
 
 const PaikkaCheckout = () => {
   const [quantities, setQuantities] = useState(() => Object.fromEntries(MENU_ITEMS.map((item) => [item.sku, 0])));
@@ -35,12 +37,17 @@ const PaikkaCheckout = () => {
   const hasItems = subtotalCents > 0;
   const emailValid = isValidEmail(email);
   const firstNameValid = firstName.trim().length > 0;
-  const canSubmit = hasItems && emailValid && firstNameValid && !isSubmitting;
 
-  const summaryItems = MENU_ITEMS.filter((item) => (quantities[item.sku] ?? 0) > 0).map((item) => ({
-    item,
-    qty: quantities[item.sku] ?? 0,
-  }));
+  const summaryItems = useMemo(
+    () =>
+      MENU_ITEMS.filter((item) => (quantities[item.sku] ?? 0) > 0).map((item) => ({
+        item,
+        qty: quantities[item.sku] ?? 0,
+      })),
+    [quantities]
+  );
+
+  const { cardLoaded, error: cardError, loadingScript, tokenize } = useSquareCard('#paikka-card-container', true, []);
 
   const handleQuantityChange = (sku, delta) => {
     setQuantities((prev) => {
@@ -51,7 +58,12 @@ const PaikkaCheckout = () => {
     });
   };
 
-  const buildPayload = () => ({
+  const handleAddToCart = (sku) => {
+    setError(null);
+    handleQuantityChange(sku, 1);
+  };
+
+  const buildCheckoutPayload = () => ({
     items: summaryItems.map(({ item, qty }) => ({ sku: item.sku, qty })),
     customer: {
       firstName: firstName.trim(),
@@ -61,9 +73,30 @@ const PaikkaCheckout = () => {
     tipCents,
   });
 
+  const buildEncodedState = () =>
+    base64UrlEncode({
+      email: email.trim(),
+      firstName: firstName.trim(),
+      lastName: lastName.trim() || undefined,
+      items: summaryItems.map(({ item, qty }) => ({ sku: item.sku, qty })),
+      tipCents,
+    });
+
   const handleCheckout = async () => {
-    if (!canSubmit) {
-      setError('Add at least one sandwich and enter your contact info.');
+    if (!hasItems) {
+      setError('Add at least one sandwich to your cart.');
+      return;
+    }
+    if (!firstNameValid) {
+      setError('Enter your first name so we can hold your order.');
+      return;
+    }
+    if (!emailValid) {
+      setError('Enter a valid email so we can send your QR code.');
+      return;
+    }
+    if (!cardLoaded) {
+      setError('Secure card entry is still loading. Please try again in a moment.');
       return;
     }
 
@@ -71,26 +104,48 @@ const PaikkaCheckout = () => {
     setError(null);
 
     try {
-      const response = await fetch('/api/paikka/checkout', {
+      let token;
+      try {
+        token = await tokenize();
+      } catch (tokenErr) {
+        throw new Error(tokenErr?.message || 'Unable to verify your card details.');
+      }
+
+      const response = await fetch('/api/paikka/pay', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(buildPayload()),
+        body: JSON.stringify({ ...buildCheckoutPayload(), token }),
       });
 
       const data = await response.json().catch(() => ({}));
       if (!response.ok) {
         throw new Error(data?.error || 'Checkout failed. Please try again.');
       }
-      if (!data?.checkoutUrl) {
-        throw new Error('Missing checkout URL in response.');
+
+      const paymentReference =
+        data?.paymentId ||
+        data?.payment_id ||
+        data?.transactionId ||
+        data?.transaction_id ||
+        data?.id;
+
+      if (!paymentReference) {
+        throw new Error('Missing payment reference from Square.');
       }
-      window.location.href = data.checkoutUrl;
+
+      const params = new URLSearchParams();
+      params.set('state', buildEncodedState());
+      params.set('paymentId', paymentReference);
+      window.location.href = `/paikka/success?${params.toString()}`;
     } catch (err) {
       console.error('Paikka checkout failed', err);
       setError(err instanceof Error ? err.message : 'Checkout failed. Please try again.');
       setIsSubmitting(false);
     }
   };
+
+  const canSubmit = hasItems && emailValid && firstNameValid && cardLoaded && !isSubmitting;
+  const showCustomTipInput = tipSelection === 'custom';
 
   return (
     <section className="mx-auto max-w-5xl space-y-10">
@@ -104,44 +159,42 @@ const PaikkaCheckout = () => {
 
       <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
         <div className="space-y-6">
-          {MENU_ITEMS.map((item) => {
-            const qty = quantities[item.sku] ?? 0;
+          {GROUPED_MENU.map((group) => {
+            const hasDairyFree = group.variants.some((variant) => variant.isDairyFree);
             return (
-              <div key={item.sku} className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div key={group.baseSku} className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+                <div className="space-y-4">
                   <div className="space-y-2">
-                    <h2 className="text-xl font-semibold text-neutral-900">{item.title}</h2>
-                    <p className="text-sm text-neutral-600">{item.description}</p>
+                    <h2 className="text-xl font-semibold text-neutral-900">{group.title}</h2>
+                    <p className="text-sm text-neutral-600">{group.description}</p>
                     <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-500">
-                      <span className="font-medium text-neutral-900">{formatCurrency(item.presalePriceCents)}</span>
+                      <span className="font-medium text-neutral-900">{formatCurrency(group.presalePriceCents)}</span>
                       <span className="opacity-80">Presale</span>
                       <span aria-hidden="true">·</span>
-                      <span className="line-through">{formatCurrency(item.regularPriceCents)}</span>
+                      <span className="line-through">{formatCurrency(group.regularPriceCents)}</span>
                       <span className="opacity-80">Door price</span>
                     </div>
                   </div>
-                  <div className="flex items-center gap-3 self-stretch sm:flex-col sm:items-end sm:justify-between">
-                    <div className="flex items-center rounded-full border border-neutral-300 bg-white shadow-sm">
-                      <button
+
+                  <div className="flex flex-wrap gap-3">
+                    {group.variants.map((variant) => (
+                      <Button
+                        key={variant.sku}
                         type="button"
-                        onClick={() => handleQuantityChange(item.sku, -1)}
-                        className="px-3 py-2 text-lg font-semibold text-neutral-700 hover:text-neutral-900"
-                        aria-label={`Remove one ${item.title}`}
+                        onClick={() => handleAddToCart(variant.sku)}
+                        variant={variant.isDairyFree ? 'outline' : 'default'}
+                        className="flex-1 min-w-[10rem]"
                       >
-                        -
-                      </button>
-                      <span className="min-w-[2rem] text-center text-base font-semibold text-neutral-900">{qty}</span>
-                      <button
-                        type="button"
-                        onClick={() => handleQuantityChange(item.sku, 1)}
-                        className="px-3 py-2 text-lg font-semibold text-neutral-700 hover:text-neutral-900"
-                        aria-label={`Add one ${item.title}`}
-                      >
-                        +
-                      </button>
-                    </div>
-                    <span className="text-sm text-neutral-500">Add to order</span>
+                        {variant.isDairyFree ? 'Add dairy-free' : 'Add to cart'}
+                      </Button>
+                    ))}
                   </div>
+
+                  {hasDairyFree && (
+                    <p className="text-xs text-neutral-500">
+                      Dairy-free sandwiches are prepared without cheese.
+                    </p>
+                  )}
                 </div>
               </div>
             );
@@ -199,48 +252,95 @@ const PaikkaCheckout = () => {
                     type="button"
                     onClick={() => setTipSelection(option.value)}
                     className={clsx(
-                      'rounded-full border px-4 py-2 text-sm font-medium transition',
+                      'rounded-full border px-4 py-2 text-sm font-medium transition-colors',
                       tipSelection === option.value
-                        ? 'border-accent bg-orange-50 text-orange-700 shadow-sm'
-                        : 'border-neutral-200 bg-white text-neutral-600 hover:border-orange-200'
+                        ? 'border-accent bg-accent/10 text-accent'
+                        : 'border-neutral-300 text-neutral-600 hover:border-neutral-400 hover:text-neutral-800'
                     )}
                   >
                     {option.label}
                   </button>
                 ))}
               </div>
-              {tipSelection === 'custom' && (
-                <input
-                  className={inputClassName}
-                  inputMode="decimal"
-                  placeholder="Tip amount in dollars"
-                  value={customTip}
-                  onChange={(event) => setCustomTip(event.target.value)}
-                />
+              {showCustomTipInput && (
+                <div className="flex items-center gap-3">
+                  <label className="text-sm text-neutral-600" htmlFor="custom-tip">
+                    Custom tip
+                  </label>
+                  <input
+                    id="custom-tip"
+                    type="text"
+                    inputMode="decimal"
+                    value={customTip}
+                    onChange={(event) => setCustomTip(event.target.value)}
+                    className="w-32 rounded-md border border-neutral-300 px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-orange-200"
+                    placeholder="$5.00"
+                  />
+                </div>
               )}
             </div>
 
-            <div className="space-y-3 rounded-xl bg-neutral-50 p-4">
-              <h4 className="text-sm font-semibold text-neutral-700">Order summary</h4>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium text-neutral-700">Your order</p>
+                {hasItems && <span className="text-xs text-neutral-500">Tap +/- to adjust quantities</span>}
+              </div>
               {summaryItems.length === 0 ? (
-                <p className="text-sm text-neutral-500">Add a sandwich to see your total.</p>
+                <p className="text-sm text-neutral-500">Add sandwiches to your cart to continue.</p>
               ) : (
-                <ul className="space-y-2 text-sm text-neutral-600">
+                <ul className="space-y-3">
                   {summaryItems.map(({ item, qty }) => (
-                    <li key={item.sku} className="flex justify-between">
-                      <span>
-                        {item.title} x {qty}
-                      </span>
-                      <span>{formatCurrency(item.presalePriceCents * qty)}</span>
+                    <li key={item.sku} className="flex items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium text-neutral-900">
+                          {item.summaryTitle || item.title}
+                        </p>
+                        <p className="text-xs text-neutral-500">
+                          {item.isDairyFree ? 'Dairy-free · prepared without cheese' : 'Contains dairy'}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleQuantityChange(item.sku, -1)}
+                          className="h-8 w-8 rounded-full border border-neutral-300 text-sm font-semibold text-neutral-600 hover:border-neutral-400 hover:text-neutral-900"
+                          aria-label={`Remove one ${item.summaryTitle || item.title}`}
+                        >
+                          −
+                        </button>
+                        <span className="min-w-[2rem] text-center text-base font-semibold text-neutral-900">{qty}</span>
+                        <button
+                          type="button"
+                          onClick={() => handleQuantityChange(item.sku, 1)}
+                          className="h-8 w-8 rounded-full border border-neutral-300 text-sm font-semibold text-neutral-600 hover:border-neutral-400 hover:text-neutral-900"
+                          aria-label={`Add one ${item.summaryTitle || item.title}`}
+                        >
+                          +
+                        </button>
+                      </div>
                     </li>
                   ))}
                 </ul>
               )}
-              <div className="flex justify-between text-sm text-neutral-600">
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-neutral-700">Payment details</p>
+              <div className="rounded-lg border border-dashed border-neutral-300 p-3">
+                <div id="paikka-card-container" className="min-h-[56px]"></div>
+              </div>
+              {loadingScript && (
+                <p className="text-xs text-neutral-500">Loading secure Square card entry…</p>
+              )}
+              {cardError && <p className="text-xs text-red-600">{cardError}</p>}
+            </div>
+
+            <div className="space-y-1 text-sm text-neutral-600">
+              <div className="flex justify-between">
                 <span>Subtotal</span>
                 <span>{formatCurrency(subtotalCents)}</span>
               </div>
-              <div className="flex justify-between text-sm text-neutral-600">
+              <div className="flex justify-between">
                 <span>Gratuity</span>
                 <span>{formatCurrency(tipCents)}</span>
               </div>
@@ -250,20 +350,15 @@ const PaikkaCheckout = () => {
               </div>
             </div>
 
-            {error && <p className="text-sm text-rose-600">{error}</p>}
+            {error && <p className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</p>}
 
             <Button type="submit" className="w-full" disabled={!canSubmit}>
-              {isSubmitting ? 'Redirecting...' : 'Pay with Square'}
+              {isSubmitting ? 'Processing payment…' : `Pay ${formatCurrency(totalCents)}`}
             </Button>
-            {!hasItems && <p className="text-xs text-neutral-500">Select at least one sandwich to enable checkout.</p>}
-            {!emailValid && email.length > 0 && (
-              <p className="text-xs text-rose-600">Enter a valid email address to receive your QR code.</p>
-            )}
+            <p className="text-xs text-neutral-500">
+              Your receipt and QR code will arrive by email within a few minutes after payment.
+            </p>
           </form>
-          <p className="text-xs text-neutral-500">
-            After payment we will email your QR code and backup code. Bring either to the Paikka pickup window during the
-            presale pickup time.
-          </p>
         </aside>
       </div>
     </section>

--- a/src/features/paikka/menu.js
+++ b/src/features/paikka/menu.js
@@ -1,19 +1,51 @@
 const MENU_ITEMS = [
   {
     sku: 'SMOKED_CHICKEN',
-    title: 'Smoked chicken',
-    description: 'Served on sourdough focaccia. 100% local ingredients.',
+    baseSku: 'SMOKED_CHICKEN',
+    title: 'Smoked chicken sandwich',
+    summaryTitle: 'Smoked chicken sandwich',
+    description: 'Roasted cabbage mostarda, apple and celery, colby cheese.',
     presalePriceCents: 1400,
     regularPriceCents: 1600,
-    squareName: 'Smoked chicken on sourdough focaccia',
+    squareName: 'Smoked chicken sandwich on sourdough focaccia',
+    variantLabel: 'Standard',
+    isDairyFree: false,
+  },
+  {
+    sku: 'SMOKED_CHICKEN_DF',
+    baseSku: 'SMOKED_CHICKEN',
+    title: 'Smoked chicken sandwich',
+    summaryTitle: 'Smoked chicken sandwich (dairy free)',
+    description: 'Roasted cabbage mostarda, apple and celery. Dairy-free option served without cheese.',
+    presalePriceCents: 1400,
+    regularPriceCents: 1600,
+    squareName: 'Smoked chicken sandwich (dairy free) on sourdough focaccia',
+    variantLabel: 'Dairy free',
+    isDairyFree: true,
   },
   {
     sku: 'PUMPKIN_ROMESCO',
-    title: 'Pumpkin & romesco',
-    description: 'Served on sourdough focaccia. 100% local ingredients.',
+    baseSku: 'PUMPKIN_ROMESCO',
+    title: 'Marinated squash sandwich',
+    summaryTitle: 'Marinated squash sandwich',
+    description: 'Romesco, spinach, gruyere.',
     presalePriceCents: 1300,
     regularPriceCents: 1500,
-    squareName: 'Pumpkin & romesco on sourdough focaccia',
+    squareName: 'Marinated squash sandwich on sourdough focaccia',
+    variantLabel: 'Standard',
+    isDairyFree: false,
+  },
+  {
+    sku: 'PUMPKIN_ROMESCO_DF',
+    baseSku: 'PUMPKIN_ROMESCO',
+    title: 'Marinated squash sandwich',
+    summaryTitle: 'Marinated squash sandwich (dairy free)',
+    description: 'Romesco, spinach. Dairy-free option served without gruyere.',
+    presalePriceCents: 1300,
+    regularPriceCents: 1500,
+    squareName: 'Marinated squash sandwich (dairy free) on sourdough focaccia',
+    variantLabel: 'Dairy free',
+    isDairyFree: true,
   },
 ];
 
@@ -23,8 +55,32 @@ const currency = new Intl.NumberFormat('en-US', { style: 'currency', currency: '
 
 const formatCurrency = (cents) => currency.format(cents / 100);
 
-export { MENU_ITEMS, MENU_LOOKUP, formatCurrency };
+const groupedMenuMap = MENU_ITEMS.reduce((map, item) => {
+  const key = item.baseSku || item.sku;
+  if (!map.has(key)) {
+    map.set(key, {
+      baseSku: key,
+      title: item.title,
+      description: item.description,
+      presalePriceCents: item.presalePriceCents,
+      regularPriceCents: item.regularPriceCents,
+      variants: [],
+    });
+  }
+  map.get(key).variants.push(item);
+  return map;
+}, new Map());
+
+const GROUPED_MENU = Array.from(groupedMenuMap.values()).map((entry) => ({
+  ...entry,
+  variants: entry.variants.sort((a, b) => {
+    if (a.isDairyFree === b.isDairyFree) return 0;
+    return a.isDairyFree ? 1 : -1;
+  }),
+}));
+
+export { MENU_ITEMS, MENU_LOOKUP, formatCurrency, GROUPED_MENU };
 
 if (typeof module !== 'undefined') {
-  module.exports = { MENU_ITEMS, MENU_LOOKUP, formatCurrency };
+  module.exports = { MENU_ITEMS, MENU_LOOKUP, formatCurrency, GROUPED_MENU };
 }

--- a/src/features/paikka/utils.js
+++ b/src/features/paikka/utils.js
@@ -1,3 +1,5 @@
+const { MENU_LOOKUP } = require('./menu');
+
 const TIP_OPTIONS = [
   { label: '0%', value: '0' },
   { label: '10%', value: '10' },
@@ -52,7 +54,7 @@ const decodeCheckoutState = (value) => {
       sku: typeof item?.sku === 'string' ? item.sku : null,
       qty: Number(item?.qty ?? 0),
     }))
-    .filter((item) => (item.sku === 'SMOKED_CHICKEN' || item.sku === 'PUMPKIN_ROMESCO') && Number.isFinite(item.qty) && item.qty > 0);
+    .filter((item) => MENU_LOOKUP.has(item.sku) && Number.isFinite(item.qty) && item.qty > 0);
 
   return {
     email: String(parsed.email ?? ''),
@@ -98,7 +100,7 @@ const resolvePaymentReference = (params) => {
 
 const computeTotals = (state, menuLookup) => {
   if (!state) return { subtotal: 0, tip: 0, total: 0 };
-  const lookup = menuLookup ?? new Map();
+  const lookup = menuLookup ?? MENU_LOOKUP ?? new Map();
   const subtotal = state.items.reduce((sum, item) => {
     const menu = lookup.get(item.sku);
     if (!menu) return sum;

--- a/src/pages/PaikkaSuccessPage.jsx
+++ b/src/pages/PaikkaSuccessPage.jsx
@@ -123,10 +123,15 @@ const PaikkaSuccessPage = () => {
                       const menu = MENU_LOOKUP.get(item.sku);
                       if (!menu) return null;
                       return (
-                        <li key={item.sku} className="flex justify-between">
-                          <span>
-                            {menu.title} x {item.qty}
-                          </span>
+                        <li key={item.sku} className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="space-y-0.5">
+                            <span className="font-medium text-neutral-900">
+                              {menu.summaryTitle || menu.title} × {item.qty}
+                            </span>
+                            {menu.isDairyFree && (
+                              <span className="text-xs uppercase tracking-[0.2em] text-orange-600">Dairy free</span>
+                            )}
+                          </div>
                           <span>{formatCurrency(menu.presalePriceCents * item.qty)}</span>
                         </li>
                       );


### PR DESCRIPTION
## Summary
- replace the Paikka presale form with grouped sandwich cards, add-to-cart buttons, and inline Square Web Payments tokenization
- extend the Paikka menu utilities with dairy-free variants and shared grouping metadata for accurate pricing and descriptions
- add a direct Square payment endpoint and update order/success flows across web targets to recognize the new SKUs and dairy-free labels

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1d50e39a483219a95d8f2a0edf07d