### PR TITLE
Fix Paikka utils import for browser

### DIFF
--- a/src/features/paikka/utils.js
+++ b/src/features/paikka/utils.js
@@ -1,4 +1,4 @@
-const { MENU_LOOKUP } = require('./menu');
+import { MENU_LOOKUP } from './menu';
 
 const TIP_OPTIONS = [
   { label: '0%', value: '0' },


### PR DESCRIPTION
## Summary
- replace CommonJS require with ESM import in Paikka utils to avoid runtime ReferenceError in the browser

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2af3b721c832180d9e4c7f15440b3