### PR TITLE
Add Playwright coverage for key sales and email flows

### DIFF
--- a/tests/e2e/crowdfund.spec.js
+++ b/tests/e2e/crowdfund.spec.js
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { stubSquarePayments } from './utils/squareStub';
+
+test.describe('crowdfunding checkout', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubSquarePayments(page);
+  });
+
+  test('checkout form calls missing /api/crowdfund/checkout endpoint', async ({ page }) => {
+    const requests = [];
+    await page.route('**/api/crowdfund/**', async (route) => {
+      requests.push(route.request().url());
+      if (route.request().url().endsWith('/checkout')) {
+        await route.fulfill({
+          status: 404,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Not Found' }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await page.goto('/crowdfunding');
+    await page.getByRole('button', { name: 'I want pizza' }).click();
+    await page.locator('#cf-name').fill('Crowdfund Tester');
+    await page.locator('#cf-email').fill('crowdfund@example.com');
+    await page.locator('#cf-phone').fill('555-555-1234');
+    await page.locator('#pizza-qty').fill('1');
+
+    const buyButton = page.getByRole('button', { name: /Buy/ });
+    await expect(buyButton).toBeEnabled();
+    await buyButton.click();
+
+    await expect(page.getByText('Not Found')).toBeVisible();
+    expect(requests.some((url) => url.endsWith('/checkout'))).toBe(true);
+    expect(requests.some((url) => url.endsWith('/contribute'))).toBe(false);
+  });
+});

--- a/tests/e2e/foodtruck.spec.js
+++ b/tests/e2e/foodtruck.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { stubSquarePayments } from './utils/squareStub';
+
+test.describe('Food truck flows', () => {
+  test('booking dialog sends inquiry email', async ({ page }) => {
+    let payload = null;
+    await page.route('**/api/messages/submit', async (route) => {
+      payload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await page.goto('/book-food-truck');
+    await page.getByRole('button', { name: /Book the food truck/i }).click();
+    await page.getByLabel('Name / Business*').fill('Food Truck Client');
+    await page.getByLabel('Email*').fill('truck@example.com');
+    await page.getByLabel('Phone*').fill('6125551234');
+    await page.getByLabel('Event date*').fill('2025-05-10');
+    await page.getByLabel('Event location*').fill('123 Sample St');
+    await page.getByLabel('Desired cuisine').fill('Wood-fired pizza');
+    await page.getByLabel('Additional details').fill('Looking for dinner service.');
+    await page.getByRole('button', { name: /Send inquiry/i }).click();
+
+    await expect(page.getByRole('button', { name: 'Thanks!' })).toBeVisible();
+    expect(payload).toMatchObject({
+      email: 'truck@example.com',
+      subject: 'Food Truck Inquiry',
+      type: 'food_truck',
+    });
+  });
+
+  test('deposit checkout fails without Square configuration', async ({ page }) => {
+    await stubSquarePayments(page);
+
+    let called = false;
+    await page.route('**/api/food-truck/deposit', async (route) => {
+      called = true;
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'square-not-configured' }),
+      });
+    });
+
+    await page.goto('/book-food-truck');
+    await page.locator('#ft-deposit-name').fill('Deposit Client');
+    await page.locator('#ft-deposit-email').fill('deposit@example.com');
+    await page.locator('#ft-deposit-phone').fill('6125555678');
+    await page.locator('#ft-deposit-date').fill('2025-06-15');
+    await page.locator('#ft-deposit-notes').fill('Evening service.');
+
+    const payButton = page.getByRole('button', { name: /Pay/ });
+    await expect(payButton).toBeEnabled();
+    await payButton.click();
+
+    await expect(page.getByText('square-not-configured')).toBeVisible();
+    expect(called).toBe(true);
+  });
+});

--- a/tests/e2e/home.spec.js
+++ b/tests/e2e/home.spec.js
@@ -19,3 +19,50 @@ test('navigation to pricing page', async ({ page }) => {
     await expect(page).toHaveURL(/pricing/);
   }
 });
+
+test.describe('home page forms', () => {
+  test('newsletter subscribe posts to /api/subscribe', async ({ page }) => {
+    let requestBody = null;
+    await page.route('**/api/subscribe', async (route) => {
+      requestBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await page.goto('/');
+    await page.getByPlaceholder('you@example.com').first().fill('tester@example.com');
+    await page.getByRole('button', { name: 'Subscribe' }).first().click();
+
+    await expect(page.getByText("Thanks! You’re on the list.")).toBeVisible();
+    expect(requestBody).toEqual({ email: 'tester@example.com' });
+  });
+
+  test('feedback modal submits to /api/messages/submit', async ({ page }) => {
+    let payload = null;
+    await page.route('**/api/messages/submit', async (route) => {
+      payload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await page.goto('/');
+    await page.getByRole('button', { name: /provide feedback/i }).click();
+    await page.getByLabel('Name').fill('Test User');
+    await page.getByLabel('Email').fill('feedback@example.com');
+    await page.getByLabel('Message').fill('Playwright feedback message.');
+    await page.getByRole('button', { name: /Send feedback/i }).click();
+
+    await expect(page.getByText('Thanks! Sent.')).toBeVisible();
+    expect(payload).toMatchObject({
+      name: 'Test User',
+      email: 'feedback@example.com',
+      type: 'feedback',
+    });
+  });
+});

--- a/tests/e2e/paikka.spec.js
+++ b/tests/e2e/paikka.spec.js
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { stubSquarePayments } from './utils/squareStub';
+
+const encodeState = (payload) =>
+  Buffer.from(JSON.stringify(payload), 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/u, '');
+
+test.describe('Paikka presale', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubSquarePayments(page);
+  });
+
+  test('checkout posts to missing /api/paikka/pay route', async ({ page }) => {
+    let called = false;
+    await page.route('**/api/paikka/pay', async (route) => {
+      called = true;
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Not Found' }),
+      });
+    });
+
+    await page.goto('/paikka');
+    await page.getByRole('button', { name: /Add to cart/i }).first().click();
+    await page.getByLabel('First name').fill('Alex');
+    await page.getByLabel('Email').fill('alex@example.com');
+    await page.getByRole('button', { name: '0%' }).click();
+
+    const payButton = page.getByRole('button', { name: /Pay/ });
+    await expect(payButton).toBeEnabled();
+    await payButton.click();
+
+    await expect(page.getByText('Not Found')).toBeVisible();
+    expect(called).toBe(true);
+  });
+
+  test('success page fails to finalize order without backend route', async ({ page }) => {
+    const stateParam = encodeState({
+      email: 'alex@example.com',
+      firstName: 'Alex',
+      items: [{ sku: 'SMOKED_CHICKEN', qty: 1 }],
+      tipCents: 0,
+    });
+
+    await page.route('**/api/paikka/finalize', async (route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Not Found' }),
+      });
+    });
+
+    await page.goto(`/paikka/success?state=${stateParam}&paymentId=test123`);
+    await expect(page.getByText('Not Found')).toBeVisible();
+  });
+
+  test('resend email button fails when /api/paikka/resend is missing', async ({ page }) => {
+    const stateParam = encodeState({
+      email: 'alex@example.com',
+      firstName: 'Alex',
+      items: [{ sku: 'SMOKED_CHICKEN', qty: 1 }],
+      tipCents: 0,
+    });
+
+    await page.route('**/api/paikka/finalize', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          order: { email: 'alex@example.com', oid: 'order-1', jti: 'qr-123' },
+          jwt: 'token-123',
+        }),
+      });
+    });
+
+    let resendCalled = false;
+    await page.route('**/api/paikka/resend', async (route) => {
+      resendCalled = true;
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Not Found' }),
+      });
+    });
+
+    await page.goto(`/paikka/success?state=${stateParam}&paymentId=test123`);
+    await expect(page.getByText('You are all set.')).toBeVisible();
+    await page.getByRole('button', { name: /Resend email/i }).click();
+    await expect(page.getByText('We could not resend the email. Try again shortly.')).toBeVisible();
+    expect(resendCalled).toBe(true);
+  });
+});

--- a/tests/e2e/utils/squareStub.js
+++ b/tests/e2e/utils/squareStub.js
@@ -1,0 +1,36 @@
+export async function stubSquarePayments(page) {
+  await page.addInitScript(() => {
+    const createStubCard = () => ({
+      attach: async () => {},
+      destroy: async () => {},
+      tokenize: async () => ({ status: 'OK', token: 'stub-token' }),
+    });
+
+    const createPayments = () => ({
+      card: async () => createStubCard(),
+    });
+
+    window.__SQUARE_APP_ID__ = window.__SQUARE_APP_ID__ || 'sandbox-stub-app-id';
+    window.__SQUARE_LOCATION_ID__ = window.__SQUARE_LOCATION_ID__ || 'location-stub';
+    window.__SQUARE_ENV__ = window.__SQUARE_ENV__ || 'sandbox';
+
+    window.Square = window.Square || {
+      payments: async () => createPayments(),
+    };
+  });
+
+  await page.route(/https:\/\/(sandbox\.)?web\.squarecdn\.com\/v1\/square\.js/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `window.Square = window.Square || {};
+window.Square.payments = window.Square.payments || (async () => ({
+  card: async () => ({
+    attach: async () => {},
+    destroy: async () => {},
+    tokenize: async () => ({ status: 'OK', token: 'stub-token' })
+  })
+}));`,
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- expand the existing home page Playwright spec with newsletter and feedback form coverage
- add end-to-end tests for crowdfunding, Paikka presale, and food truck deposit/inquiry flows
- introduce a reusable Square payment stub helper so the UI can mount card elements in tests

## Testing
- `pnpm test:e2e` *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3297e4fd0832185c61479a042ac7a