### PR TITLE
Hide header on AACRM partner route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,6 +60,7 @@ const PaikkaSuccessPage = lazy(() => import('./pages/PaikkaSuccessPage'));
 
 const AppContent = () => {
   const location = useLocation();
+  const hideHeader = location.pathname.startsWith('/partners/aacrm');
 
   useEffect(() => {
     document.fonts?.ready?.then(() => document.body.classList.add('fonts-loaded'));
@@ -71,7 +72,7 @@ const AppContent = () => {
       <CartProvider>
         <ToastProvider>
         <div className="min-h-screen flex flex-col bg-white">
-          <Header />
+          {!hideHeader && <Header />}
           <main className="flex-1">
           <Suspense fallback={<LoadingSpinner />}>
             <AnimatePresence mode="wait">


### PR DESCRIPTION
## Summary
- hide the global header when navigating to the AACRM partner workspace so the embedded app can use the full viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4a92ba0b483219cb4c40efc2a9b54