### PR TITLE
Fix crowdfunding checkout routing and confirm fallback

### DIFF
--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -29,6 +29,7 @@ const path = require('path');
 const { logger } = require('./logger');
 const { createBrevoService } = require('./services/brevo');
 const { createCrowdfundingRouter } = require('./routes/crowdfunding');
+const crowdfundCheckoutHandler = require('../../api/crowdfund/checkout');
 const { createMessagesRouter } = require('./routes/messages');
 
 // Fallback: if critical vars are missing, also try loading project root .env
@@ -300,6 +301,14 @@ try {
 // --- API ENDPOINTS ---
 
 app.use('/api/crowdfund', createCrowdfundingRouter({ db, squareClient, logger }));
+app.all('/api/crowdfund/checkout', async (req, res, next) => {
+  try {
+    await crowdfundCheckoutHandler(req, res);
+  } catch (err) {
+    logger.error({ err, method: req.method }, 'crowdfund checkout handler failed');
+    next(err);
+  }
+});
 app.use('/api', createMessagesRouter({ logger, brevoService, getSanityClient, db }));
 
 // Diagnostic endpoint (safe): reports whether required env vars are present
@@ -401,112 +410,6 @@ try {
 // if (require.main === module) {
 //   console.info('Backend API starting (local)');
 // }
-
-// This endpoint remains the same
-app.get('/api/crowdfund/status', async (req, res) => {
-  // ... (No changes to this function)
-  try {
-    const docRef = db.collection('crowdfund').doc('status');
-    const doc = await docRef.get();
-    if (!doc.exists) {
-      const defaultData = { goal: 1000, pizzasSold: 0, funders: [] };
-      await db.collection('crowdfund').doc('status').set(defaultData);
-      return res.json(defaultData);
-    }
-    res.json(doc.data());
-  } catch (error) {
-  logger.error({ err: error }, 'crowdfund status error');
-    res.status(500).json({ error: 'Failed to read database.' });
-  }
-});
-
-// --- THIS ENDPOINT IS FULLY REBUILT ---
-app.post('/api/crowdfund/contribute', async (req, res) => {
-  const { items } = req.body;
-
-  if (!items || items.length === 0) {
-    return res.status(400).json({ error: 'Cart is empty.' });
-  }
-
-  try {
-    // Create line items for the Square Order from the cart
-    const lineItems = items.map(item => ({
-      name: item.name,
-      quantity: String(item.quantity && item.quantity > 0 ? item.quantity : (item.pizzaCount || 1)),
-      basePriceMoney: {
-        amount: item.price * 100, // Square expects amounts in cents
-        currency: 'USD',
-      },
-    }));
-
-    if (!squareClient) {
-      return res.status(500).json({ error: 'Payment provider not configured on this server.' });
-    }
-
-    // Create a payment link with Square
-    const response = await squareClient.checkoutApi.createPaymentLink({
-      idempotencyKey: uuidv4(), // Prevents accidental duplicate charges
-      order: {
-        locationId: process.env.SQUARE_LOCATION_ID,
-        lineItems: lineItems,
-      },
-      checkoutOptions: {
-        // Redirect the user back to your fundraiser page after payment
-        redirectUrl: 'https://localeffortfood.com/#/crowdfunding?payment=success',
-        // Optional: Ask for shipping address if you need to mail items
-        askForShippingAddress: true, 
-      },
-    });
-
-    // Send the URL of the payment link back to the frontend
-    res.json({
-      url: response.result.paymentLink.url,
-    });
-
-  } catch (error) {
-  logger.error({ err: error }, 'square create payment link error');
-    res.status(500).json({ error: 'Failed to create payment link.' });
-  }
-});
-
-// This endpoint is NEW. It will be used for webhooks in the future to confirm payments.
-// For now, it will handle the client-side confirmation.
-app.post('/api/crowdfund/confirm-payment', async (req, res) => {
-  const { items, funderName } = req.body;
-
-  try {
-    const pizzasInCart = items.filter(p => p.type === 'pizza').reduce((sum, item) => sum + (item.pizzaCount || 1), 0);
-    if (pizzasInCart === 0) {
-        return res.json({ success: true, message: "No pizza items to update." });
-    }
-
-  if (!db) return res.status(500).json({ error: 'Database not configured on this server.' });
-
-  const docRef = db.collection('crowdfund').doc('status');
-    await db.runTransaction(async (transaction) => {
-      const doc = await transaction.get(docRef);
-      if (!doc.exists) throw "Document does not exist!";
-      
-      const newPizzasSold = (doc.data().pizzasSold || 0) + pizzasInCart;
-      const newFunders = doc.data().funders || [];
-      newFunders.push({ name: funderName, date: new Date().toISOString() });
-      
-      transaction.update(docRef, { 
-        pizzasSold: newPizzasSold,
-        funders: newFunders
-      });
-    });
-
-  // Return the new total after successful transaction
-  const updatedDoc = await db.collection('crowdfund').doc('status').get();
-  const updatedTotal = updatedDoc.exists ? (updatedDoc.data().pizzasSold || 0) : null;
-  res.json({ success: true, newTotal: updatedTotal });
-
-  } catch (error) {
-  logger.error({ err: error }, 'confirm payment error');
-    res.status(500).json({ error: 'Failed to update database after payment.' });
-  }
-});
 
 
 app.post('/api/food-truck/deposit', async (req, res) => {

--- a/backend/api/routes/__tests__/crowdfunding.test.js
+++ b/backend/api/routes/__tests__/crowdfunding.test.js
@@ -46,4 +46,41 @@ describe('crowdfunding router', () => {
       })
     );
   });
+
+  it('creates the crowdfund status document if missing during confirm-payment', async () => {
+    let stored = null;
+    const docRef = {
+      get: vi.fn(async () => {
+        if (!stored) return { exists: false, data: () => ({}) };
+        return { exists: true, data: () => stored };
+      }),
+    };
+    const db = {
+      collection: () => ({
+        doc: () => docRef,
+      }),
+      runTransaction: async (fn) => {
+        await fn({
+          get: async () => (!stored ? { exists: false, data: () => ({}) } : { exists: true, data: () => stored }),
+          update: (_, data) => {
+            stored = { ...(stored || {}), ...data };
+          },
+          set: (_, data) => {
+            stored = data;
+          },
+        });
+      },
+    };
+
+    const app = createApp({ db });
+    const res = await request(app)
+      .post('/crowdfund/confirm-payment')
+      .send({ items: [{ type: 'pizza', pizzaCount: 2 }], funderName: 'Tester' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, newTotal: 2 });
+    expect(stored?.pizzasSold).toBe(2);
+    expect(stored?.funders).toHaveLength(1);
+    expect(stored?.funders?.[0]?.name).toBe('Tester');
+  });
 });

--- a/backend/api/routes/crowdfunding.js
+++ b/backend/api/routes/crowdfunding.js
@@ -80,17 +80,27 @@ function createCrowdfundingRouter({ db, squareClient, logger }) {
       const docRef = db.collection('crowdfund').doc('status');
       await db.runTransaction(async (transaction) => {
         const doc = await transaction.get(docRef);
-        if (!doc.exists) throw new Error('Document does not exist');
+        const current = doc.exists ? (doc.data() || {}) : {};
 
-        const current = doc.data() || {};
         const newPizzasSold = (current.pizzasSold || 0) + pizzasInCart;
         const newFunders = Array.isArray(current.funders) ? current.funders.slice() : [];
-        newFunders.push({ name: funderName, date: new Date().toISOString() });
-
-        transaction.update(docRef, {
-          pizzasSold: newPizzasSold,
-          funders: newFunders,
+        newFunders.push({
+          name: (funderName && funderName.trim()) || 'Anonymous',
+          date: new Date().toISOString(),
         });
+
+        if (doc.exists) {
+          transaction.update(docRef, {
+            pizzasSold: newPizzasSold,
+            funders: newFunders,
+          });
+        } else {
+          transaction.set(docRef, {
+            goal: typeof current.goal === 'number' ? current.goal : 1000,
+            pizzasSold: newPizzasSold,
+            funders: newFunders,
+          });
+        }
       });
 
       const updatedDoc = await docRef.get();

--- a/tests/e2e/crowdfund.spec.js
+++ b/tests/e2e/crowdfund.spec.js
@@ -6,15 +6,15 @@ test.describe('crowdfunding checkout', () => {
     await stubSquarePayments(page);
   });
 
-  test('checkout form calls missing /api/crowdfund/checkout endpoint', async ({ page }) => {
+  test('checkout form posts to /api/crowdfund/checkout', async ({ page }) => {
     const requests = [];
     await page.route('**/api/crowdfund/**', async (route) => {
       requests.push(route.request().url());
       if (route.request().url().endsWith('/checkout')) {
         await route.fulfill({
-          status: 404,
+          status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ error: 'Not Found' }),
+          body: JSON.stringify({ ok: true }),
         });
         return;
       }
@@ -36,8 +36,8 @@ test.describe('crowdfunding checkout', () => {
     await expect(buyButton).toBeEnabled();
     await buyButton.click();
 
-    await expect(page.getByText('Not Found')).toBeVisible();
     expect(requests.some((url) => url.endsWith('/checkout'))).toBe(true);
     expect(requests.some((url) => url.endsWith('/contribute'))).toBe(false);
+    await expect(page.getByText('Thanks! Your contribution has been processed.')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- register the shared crowdfunding checkout handler on the backend API instead of duplicating logic
- make the confirm-payment transaction create the status document when missing and default funder names
- add regression coverage for the new behavior and update the e2e stub to expect a successful checkout flow

## Testing
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e4aad382748321a9b874580cc239ba