### PR TITLE
Rename footer releases link to press

### DIFF
--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -31,7 +31,7 @@ export const Footer = () => {
               href="/releases"
               className="underline underline-offset-4 hover:opacity-80"
             >
-              Releases
+              Press
             </a>
             <a
               href="https://www.tiktok.com/@localeffort"


### PR DESCRIPTION
## Summary
- update the footer navigation text for the /releases link to display "Press"

## Testing
- no tests were run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e513947ad48321bfc9e4d6c9ade2c7