### PR TITLE
Add Firestore id to crowdfunding campaign events

### DIFF
--- a/studio/schemaTypes/crowdfundingCampaign.js
+++ b/studio/schemaTypes/crowdfundingCampaign.js
@@ -154,6 +154,12 @@ export default {
             { name: 'foodType', title: 'Type of Food', type: 'string' },
             { name: 'ticketsUrl', title: 'Tickets URL', type: 'url' },
             { name: 'description', title: 'Description', type: 'array', of: [{ type: 'block' }] },
+            {
+              name: 'firestoreEventId',
+              title: 'Firestore Event ID',
+              type: 'string',
+              description: 'ID of the source Firestore event so we can sync copies.',
+            },
           ],
           preview: {
             select: { title: 'location', start: 'startDate', end: 'endDate' },


### PR DESCRIPTION
## Summary
- add the missing Firestore event id field to the crowdfunding campaign event object so it matches the public event schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e51540e7908321abe6eb6d74ee1070