### PR TITLE
Fix Square payment containers to prevent runtime crash

### DIFF
--- a/src/components/home/GiftCardDialog.jsx
+++ b/src/components/home/GiftCardDialog.jsx
@@ -531,9 +531,10 @@ const GiftCardDialog = ({ className = "" }) => {
 
             <section className="space-y-2">
               <p className="text-sm font-semibold text-slate-700">Payment details</p>
-              <div id="gift-card-card-container" className="min-h-[96px] rounded-lg border border-slate-200 bg-white p-3">
-                {!cardLoaded && !squareError && <p className="text-sm text-slate-500">Loading secure card entry...</p>}
-                {squareError && <p className="text-sm text-red-600">{squareError}</p>}
+              <div className="min-h-[96px] rounded-lg border border-slate-200 bg-white p-3">
+                <div id="gift-card-card-container" className="min-h-[64px]" />
+                {!cardLoaded && !squareError && <p className="mt-2 text-sm text-slate-500">Loading secure card entry...</p>}
+                {squareError && <p className="mt-2 text-sm text-red-600">{squareError}</p>}
               </div>
               <p className="text-xs text-slate-400">We use Square to process payments securely. The card is charged immediately and refunds are available on request within 14 days (if unused).</p>
             </section>

--- a/src/pages/PizzaPartyPage.jsx
+++ b/src/pages/PizzaPartyPage.jsx
@@ -634,14 +634,15 @@ const PizzaPartyPage = () => {
               {cardError && (
                 <p className="text-xs text-rose-600 pt-2">{cardError}</p>
               )}
-              <div id="pp-card-container" className="mt-4 border rounded-md p-4 bg-white min-h-[88px]" aria-label="Pizza party card form">
+              <div className="mt-4 border rounded-md p-4 bg-white" aria-label="Pizza party card form">
+                <div id="pp-card-container" className="min-h-[88px]" />
                 {!cardLoaded && !cardError && (
-                  <p className="text-xs text-neutral-500">
+                  <p className="mt-2 text-xs text-neutral-500">
                     {loadingScript ? 'Loading payment library…' : 'Initializing secure payment form…'}
                   </p>
                 )}
                 {cardError && (
-                  <div className="text-[10px] text-rose-600 space-y-1">
+                  <div className="mt-2 text-[10px] text-rose-600 space-y-1">
                     <p>{cardError}</p>
                     <FallbackLink date={selectedDate} email={email} addOnGuests={addOnEnabled ? guestCount : 0} />
                   </div>


### PR DESCRIPTION
## Summary
- wrap the Square card mount in a dedicated inner div so React no longer clears SDK-managed nodes
- adjust the Pizza Party and Gift Card payment sections to keep loading and error messaging outside of the Square container

## Testing
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c2445f5883218f4486a6b8aa9b82