### PR TITLE
Fix Square gift card dialog cleanup timing

### DIFF
--- a/src/components/home/GiftCardDialog.jsx
+++ b/src/components/home/GiftCardDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { Gift, Loader2, Mail, MapPin, Sparkles } from "lucide-react";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "../ui/dialog";
@@ -77,15 +77,16 @@ const GiftCardDialog = ({ className = "" }) => {
 
   const { cardLoaded, error: squareError, tokenize, reset: resetSquare } = useSquareCard("#gift-card-card-container", open, [amountValue]);
 
-  useEffect(() => {
-    if (!open) {
+  const handleDialogOpenChange = useCallback((nextOpen) => {
+    if (!nextOpen) {
+      resetSquare();
       setForm(initialForm);
       setStatus("idle");
       setError("");
       setSuccess(null);
-      setTimeout(() => resetSquare(), 150);
     }
-  }, [open, resetSquare]);
+    setOpen(nextOpen);
+  }, [resetSquare]);
 
   useEffect(() => {
     if (!canChoosePhysical && form.cardType === "physical") {
@@ -273,7 +274,7 @@ const GiftCardDialog = ({ className = "" }) => {
           <button
             type="button"
             className="btn btn-primary"
-            onClick={() => setOpen(false)}
+            onClick={() => handleDialogOpenChange(false)}
           >
             Close
           </button>
@@ -287,7 +288,7 @@ const GiftCardDialog = ({ className = "" }) => {
       <Helmet>
         <script type="application/ld+json">{JSON.stringify(productSchema)}</script>
       </Helmet>
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogTrigger asChild>
         <button className={cn("btn btn-primary flex items-center gap-2 shadow-sm", className)}>
           <Gift className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- reset the Square card instance before closing the gift card dialog to prevent DOM removal errors
- centralize dialog open state changes so the success close button uses the same cleanup logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c27ef3208321873bc3b9a64b3d12