### PR TITLE
Add API for pizza feedback entries and integrate UI

### DIFF
--- a/backend/api/routes/__tests__/crowdfunding.test.js
+++ b/backend/api/routes/__tests__/crowdfunding.test.js
@@ -83,4 +83,84 @@ describe('crowdfunding router', () => {
     expect(stored?.funders).toHaveLength(1);
     expect(stored?.funders?.[0]?.name).toBe('Tester');
   });
+
+  it('stores and retrieves pizza feedback entries', async () => {
+    const stored = [];
+    const feedbackCollection = {
+      add: vi.fn(async (data) => {
+        const entry = { ...data, id: `doc-${stored.length + 1}` };
+        stored.push(entry);
+        return { id: entry.id };
+      }),
+      orderBy: vi.fn(() => ({
+        limit: (limitVal) => ({
+          get: async () => ({
+            docs: stored
+              .slice()
+              .sort((a, b) => (b.createdAtMs || 0) - (a.createdAtMs || 0))
+              .slice(0, limitVal)
+              .map((item) => ({ id: item.id, data: () => ({ ...item }) })),
+          }),
+        }),
+      })),
+    };
+
+    const db = {
+      collection: (name) => {
+        if (name === 'crowdfund_feedback') {
+          return feedbackCollection;
+        }
+        return {
+          doc: () => ({ get: async () => ({ exists: false, data: () => ({}) }) }),
+        };
+      },
+    };
+
+    const app = createApp({ db });
+
+    const postRes = await request(app)
+      .post('/crowdfund/pizza-feedback')
+      .send({ name: 'Casey', message: 'Loved the basil and char.' });
+
+    expect(postRes.status).toBe(200);
+    expect(postRes.body.entry).toMatchObject({
+      name: 'Casey',
+      message: 'Loved the basil and char.',
+    });
+    expect(feedbackCollection.add).toHaveBeenCalledTimes(1);
+
+    const getRes = await request(app).get('/crowdfund/pizza-feedback?limit=5');
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.entries).toHaveLength(1);
+    expect(getRes.body.entries[0]).toMatchObject({
+      name: 'Casey',
+      message: 'Loved the basil and char.',
+    });
+    expect(feedbackCollection.orderBy).toHaveBeenCalledWith('createdAtMs', 'desc');
+  });
+
+  it('rejects pizza feedback submissions without a message', async () => {
+    const feedbackCollection = {
+      add: vi.fn(),
+      orderBy: vi.fn(() => ({
+        limit: () => ({ get: async () => ({ docs: [] }) }),
+      })),
+    };
+
+    const db = {
+      collection: (name) => {
+        if (name === 'crowdfund_feedback') return feedbackCollection;
+        return {
+          doc: () => ({ get: async () => ({ exists: false, data: () => ({}) }) }),
+        };
+      },
+    };
+
+    const app = createApp({ db });
+    const res = await request(app).post('/crowdfund/pizza-feedback').send({ name: 'Casey' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+    expect(feedbackCollection.add).not.toHaveBeenCalled();
+  });
 });

--- a/backend/api/routes/crowdfunding.js
+++ b/backend/api/routes/crowdfunding.js
@@ -4,6 +4,34 @@ const { v4: uuidv4 } = require('uuid');
 function createCrowdfundingRouter({ db, squareClient, logger }) {
   const router = express.Router();
 
+  const FEEDBACK_COLLECTION = 'crowdfund_feedback';
+
+  const sanitizeName = (value) => {
+    const str = String(value || '').replace(/\s+/g, ' ').trim();
+    if (!str) return '';
+    return str.slice(0, 120);
+  };
+
+  const sanitizeMessage = (value) => {
+    const str = String(value || '').replace(/\r/g, '').trim();
+    if (!str) return '';
+    return str.slice(0, 600);
+  };
+
+  const mapFeedbackDoc = (doc) => {
+    if (!doc) return null;
+    const data = typeof doc.data === 'function' ? doc.data() : doc;
+    if (!data) return null;
+    const message = sanitizeMessage(data.message);
+    if (!message) return null;
+    return {
+      id: doc.id || data.id || `feedback-${Date.now()}`,
+      name: sanitizeName(data.name) || 'Anonymous pizza fan',
+      message,
+      createdAt: data.createdAt || null,
+    };
+  };
+
   router.get('/status', async (req, res) => {
     try {
       if (!db) {
@@ -109,6 +137,72 @@ function createCrowdfundingRouter({ db, squareClient, logger }) {
     } catch (error) {
       if (logger) logger.error({ err: error }, 'confirm payment error');
       return res.status(500).json({ error: 'Failed to update database after payment.' });
+    }
+  });
+
+  router.get('/pizza-feedback', async (req, res) => {
+    try {
+      if (!db) {
+        return res.status(503).json({ error: 'Feedback storage unavailable' });
+      }
+
+      let limit = parseInt(req.query.limit, 10);
+      if (!Number.isFinite(limit) || limit <= 0) limit = 8;
+      limit = Math.min(limit, 20);
+
+      const snapshot = await db
+        .collection(FEEDBACK_COLLECTION)
+        .orderBy('createdAtMs', 'desc')
+        .limit(limit)
+        .get();
+
+      const entries = Array.isArray(snapshot?.docs)
+        ? snapshot.docs
+            .map((doc) => mapFeedbackDoc({ id: doc.id, data: () => doc.data() }))
+            .filter(Boolean)
+        : [];
+
+      return res.json({ entries });
+    } catch (error) {
+      if (logger) logger.error({ err: error }, 'pizza feedback list error');
+      return res.status(500).json({ error: 'Failed to load pizza feedback.' });
+    }
+  });
+
+  router.post('/pizza-feedback', async (req, res) => {
+    try {
+      if (!db) {
+        return res.status(503).json({ error: 'Feedback storage unavailable' });
+      }
+
+      const name = sanitizeName(req.body?.name);
+      const message = sanitizeMessage(req.body?.message);
+
+      if (!message) {
+        return res.status(400).json({ error: 'Please share a quick note about the pizza.' });
+      }
+
+      const entry = {
+        name: name || 'Anonymous pizza fan',
+        message,
+        createdAt: new Date().toISOString(),
+        createdAtMs: Date.now(),
+        source: 'web',
+      };
+
+      let docId = null;
+      try {
+        const docRef = await db.collection(FEEDBACK_COLLECTION).add(entry);
+        docId = docRef?.id || null;
+      } catch (firestoreErr) {
+        if (logger) logger.warn({ err: firestoreErr }, 'pizza feedback write error');
+        return res.status(500).json({ error: 'Failed to save pizza feedback.' });
+      }
+
+      return res.json({ entry: { ...entry, id: docId || `feedback-${entry.createdAtMs}` } });
+    } catch (error) {
+      if (logger) logger.error({ err: error }, 'pizza feedback submit error');
+      return res.status(500).json({ error: 'Failed to save pizza feedback.' });
     }
   });
 

--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -168,6 +168,9 @@ const CrowdfundingPage = () => {
   const [feedbackNotice, setFeedbackNotice] = useState('');
   const [feedbackStatus, setFeedbackStatus] = useState('idle'); // idle | error | success
   const [feedbackEntries, setFeedbackEntries] = useState([]);
+  const [feedbackSubmitting, setFeedbackSubmitting] = useState(false);
+  const [feedbackLoading, setFeedbackLoading] = useState(false);
+  const [feedbackFetchError, setFeedbackFetchError] = useState('');
   // Gallery state (lazy-loaded when tab activated)
   const [galleryImages, setGalleryImages] = useState([]);
   const [galleryLoading, setGalleryLoading] = useState(false);
@@ -205,6 +208,48 @@ const CrowdfundingPage = () => {
         .finally(() => setGalleryLoading(false));
     }
   }, [activeTab]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setFeedbackLoading(true);
+    setFeedbackFetchError('');
+
+    const loadFeedback = async () => {
+      try {
+        const res = await fetch('/api/crowdfund/pizza-feedback?limit=8');
+        let data = null;
+        try {
+          data = await res.json();
+        } catch (_) {
+          data = null;
+        }
+        if (!res.ok) {
+          const message = (data && data.error) || 'Unable to reach the pizza feedback service right now.';
+          throw new Error(message);
+        }
+        const entries = Array.isArray(data?.entries)
+          ? data.entries.filter((entry) => entry && entry.message)
+          : [];
+        if (!cancelled) {
+          setFeedbackEntries(entries);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setFeedbackFetchError(err?.message || 'Unable to reach the pizza feedback service right now.');
+        }
+      } finally {
+        if (!cancelled) {
+          setFeedbackLoading(false);
+        }
+      }
+    };
+
+    loadFeedback();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   // Simple client-side validators
   const emailValid = useMemo(() => !email || /.+@.+\..+/.test(email), [email]);
   const phoneDigits = useMemo(() => phone.replace(/\D/g, ''), [phone]);
@@ -408,8 +453,10 @@ const CrowdfundingPage = () => {
   };
 
   const handleFeedbackSubmit = useCallback(
-    (event) => {
+    async (event) => {
       event.preventDefault();
+      if (feedbackSubmitting) return;
+
       const name = feedbackName.trim();
       const message = feedbackMessage.trim();
 
@@ -419,20 +466,64 @@ const CrowdfundingPage = () => {
         return;
       }
 
-      setFeedbackEntries((prev) => [
-        {
-          id: `feedback-${Date.now()}`,
-          name: name || 'Anonymous pizza fan',
-          message,
-        },
-        ...prev,
-      ].slice(0, 8));
-      setFeedbackName('');
-      setFeedbackMessage('');
-      setFeedbackStatus('success');
-      setFeedbackNotice('Thanks for spreading the pizza love!');
+      setFeedbackStatus('idle');
+      setFeedbackNotice('');
+      setFeedbackSubmitting(true);
+
+      try {
+        const res = await fetch('/api/crowdfund/pizza-feedback', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name, message }),
+        });
+
+        let data = null;
+        try {
+          data = await res.json();
+        } catch (_) {
+          data = null;
+        }
+
+        if (!res.ok) {
+          const messageText = (data && data.error) || 'We had trouble saving your pizza note. Please try again.';
+          throw new Error(messageText);
+        }
+
+        const entryFromServer =
+          data && data.entry && data.entry.message
+            ? {
+                id: data.entry.id || `feedback-${Date.now()}`,
+                name: data.entry.name || 'Anonymous pizza fan',
+                message: data.entry.message,
+              }
+            : null;
+
+        const nextEntry =
+          entryFromServer || {
+            id: `feedback-${Date.now()}`,
+            name: name || 'Anonymous pizza fan',
+            message,
+          };
+
+        setFeedbackEntries((prev) => {
+          const safePrev = Array.isArray(prev)
+            ? prev.filter((item) => item && item.id !== nextEntry.id)
+            : [];
+          return [nextEntry, ...safePrev].slice(0, 8);
+        });
+        setFeedbackFetchError('');
+        setFeedbackName('');
+        setFeedbackMessage('');
+        setFeedbackStatus('success');
+        setFeedbackNotice('Thanks for spreading the pizza love!');
+      } catch (err) {
+        setFeedbackStatus('error');
+        setFeedbackNotice(err?.message || 'We had trouble saving your pizza note. Please try again.');
+      } finally {
+        setFeedbackSubmitting(false);
+      }
     },
-    [feedbackMessage, feedbackName]
+    [feedbackMessage, feedbackName, feedbackSubmitting]
   );
 
   // Destructure frequently used fields from campaign data (safe even if null)
@@ -1476,14 +1567,16 @@ const CrowdfundingPage = () => {
                     {feedbackNotice}
                   </p>
                 )}
-                <Button type="submit" className="w-full sm:w-auto">
-                  Share feedback
+                <Button type="submit" className="w-full sm:w-auto" disabled={feedbackSubmitting}>
+                  {feedbackSubmitting ? 'Sharing pizza love…' : 'Share feedback'}
                 </Button>
               </form>
             </div>
             <div className="md:w-1/2 space-y-4">
               <h3 className="text-lg font-semibold text-slate-900">Recent happy pizza thoughts</h3>
-              {feedbackEntries.length > 0 ? (
+              {feedbackLoading ? (
+                <p className="text-sm text-slate-500">Loading pizza love…</p>
+              ) : feedbackEntries.length > 0 ? (
                 <ul className="space-y-4">
                   {feedbackEntries.map((entry) => (
                     <li
@@ -1492,15 +1585,20 @@ const CrowdfundingPage = () => {
                     >
                       <p className="text-sm text-amber-900">“{entry.message}”</p>
                       <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-amber-700">
-                        — {entry.name}
+                        — {entry.name || 'Anonymous pizza fan'}
                       </p>
                     </li>
                   ))}
                 </ul>
               ) : (
                 <p className="text-sm text-slate-500">
-                  No pizza notes yet—be the first to share your experience!
+                  {feedbackFetchError
+                    ? 'We couldn’t load recent pizza notes. Share yours to kick things off!'
+                    : 'No pizza notes yet—be the first to share your experience!'}
                 </p>
+              )}
+              {feedbackFetchError && (
+                <p className="text-xs text-red-600">{feedbackFetchError}</p>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add Firestore-backed pizza feedback endpoints under /api/crowdfund
- cover the new pizza feedback endpoints with router unit tests
- fetch and submit crowdfunding pizza feedback from the UI with loading and error states

## Testing
- pnpm vitest run backend/api/routes/__tests__/crowdfunding.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5c212a40483218acac9807ee153af