### PR TITLE
Add image fallbacks for Personal Chef Wisconsin page

### DIFF
--- a/src/pages/PersonalChefWisconsin.jsx
+++ b/src/pages/PersonalChefWisconsin.jsx
@@ -15,9 +15,24 @@ export default function PersonalChefWisconsinPage() {
   const img2 = cloud('site/gallery/wisconsin-meal-prep');
   const img3 = cloud('site/gallery/wisconsin-event');
   const images = [
-    { ...img1, alt: 'Farm dinner — Western Wisconsin', caption: 'Farm dinner in Western Wisconsin — Local Effort.' },
-    { ...img2, alt: 'Weekly meal prep — Wisconsin', caption: 'Weekly meal prep services in Western Wisconsin.' },
-    { ...img3, alt: 'Intimate event catering — Wisconsin', caption: 'Small event catering in Western Wisconsin.' },
+    {
+      ...img1,
+      alt: 'Farm dinner — Western Wisconsin',
+      caption: 'Farm dinner in Western Wisconsin — Local Effort.',
+      fallbackSrc: '/gallery/5Z0A5637-Edit.jpg',
+    },
+    {
+      ...img2,
+      alt: 'Weekly meal prep — Wisconsin',
+      caption: 'Weekly meal prep services in Western Wisconsin.',
+      fallbackSrc: '/gallery/IMG_9262.jpg',
+    },
+    {
+      ...img3,
+      alt: 'Intimate event catering — Wisconsin',
+      caption: 'Small event catering in Western Wisconsin.',
+      fallbackSrc: '/gallery/5Z0A5724-Edit.jpg',
+    },
   ].map((i) => ({ ...i, thumb: i.src400 }));
   const faq = [
     { q: 'Do you serve the St. Croix Valley?', a: 'Yes — we regularly serve Hudson, River Falls, and nearby communities.' },

--- a/src/pages/_CityPage.jsx
+++ b/src/pages/_CityPage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 
 const CityPage = ({ city, h1, description, canonical, images, faq }) => {
@@ -14,6 +14,21 @@ const CityPage = ({ city, h1, description, canonical, images, faq }) => {
     description: img.caption || img.alt,
     copyrightHolder: "Local Effort Food Co."
   }));
+  const handleImageError = useCallback((event, fallbackSrc) => {
+    if (!fallbackSrc) {
+      return;
+    }
+
+    const target = event.currentTarget;
+
+    if (target.dataset.fallbackApplied === 'true') {
+      return;
+    }
+
+    target.dataset.fallbackApplied = 'true';
+    target.src = fallbackSrc;
+    target.removeAttribute('srcset');
+  }, []);
   const serviceLd = useMemo(() => ({
     "@context": "https://schema.org",
     "@type": "ProfessionalService",
@@ -116,6 +131,7 @@ const CityPage = ({ city, h1, description, canonical, images, faq }) => {
               height="800"
               alt={img.alt}
               className="w-full h-auto rounded"
+              onError={(event) => handleImageError(event, img.fallbackSrc)}
             />
             <figcaption className="text-sm text-neutral-600 mt-2">{img.caption || img.alt}</figcaption>
           </figure>
@@ -124,7 +140,7 @@ const CityPage = ({ city, h1, description, canonical, images, faq }) => {
 
       <noscript>
         {images.map((img, idx) => (
-          <img key={`ns-${idx}`} src={img.src} alt={img.alt} />
+          <img key={`ns-${idx}`} src={img.fallbackSrc || img.src} alt={img.alt} />
         ))}
       </noscript>
 


### PR DESCRIPTION
## Summary
- add local fallback sources for the Wisconsin personal chef gallery tiles
- update the shared city page gallery to swap to fallbacks when Cloudinary images fail to load

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c2cd6c8c83219dd2372aadde29af