### PR TITLE
Handle crowdfund status fallback when DB unavailable

### DIFF
--- a/backend/api/routes/__tests__/crowdfunding.test.js
+++ b/backend/api/routes/__tests__/crowdfunding.test.js
@@ -8,13 +8,29 @@ describe('crowdfunding router', () => {
     const router = createCrowdfundingRouter({
       db: overrides.db || null,
       squareClient: overrides.squareClient || null,
-      logger: overrides.logger || { error: vi.fn() },
+      logger: overrides.logger || { error: vi.fn(), warn: vi.fn() },
     });
     const app = express();
     app.use(express.json());
     app.use('/crowdfund', router);
     return app;
   };
+
+  it('returns fallback status when the database is unavailable', async () => {
+    const warn = vi.fn();
+    const app = createApp({ logger: { warn, error: vi.fn() } });
+
+    const res = await request(app).get('/crowdfund/status');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      goal: 1000,
+      pizzasSold: 0,
+      funders: [],
+      source: 'fallback',
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
 
   it('rejects empty carts', async () => {
     const app = createApp();

--- a/backend/api/routes/crowdfunding.js
+++ b/backend/api/routes/crowdfunding.js
@@ -32,11 +32,26 @@ function createCrowdfundingRouter({ db, squareClient, logger }) {
     };
   };
 
+  const fallbackStatus = () => ({
+    goal: 1000,
+    pizzasSold: 0,
+    funders: [],
+    source: 'fallback',
+  });
+
   router.get('/status', async (req, res) => {
-    try {
-      if (!db) {
-        return res.status(500).json({ error: 'Failed to read database.' });
+    const respondWithFallback = () => {
+      if (logger?.warn) {
+        logger.warn('crowdfund status requested but database unavailable; returning fallback data');
       }
+      return res.json(fallbackStatus());
+    };
+
+    if (!db) {
+      return respondWithFallback();
+    }
+
+    try {
       const docRef = db.collection('crowdfund').doc('status');
       const doc = await docRef.get();
       if (!doc.exists) {
@@ -47,7 +62,7 @@ function createCrowdfundingRouter({ db, squareClient, logger }) {
       return res.json(doc.data());
     } catch (error) {
       if (logger) logger.error({ err: error }, 'crowdfund status error');
-      return res.status(500).json({ error: 'Failed to read database.' });
+      return respondWithFallback();
     }
   });
 


### PR DESCRIPTION
## Summary
- return a fallback crowdfund status response when the database is unavailable or errors
- log a warning for missing database instances
- extend the crowdfunding router tests to cover the fallback behavior

## Testing
- pnpm exec vitest run backend/api/routes/__tests__/crowdfunding.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5c7ae3f1c83219dd9a99b9a593d08