### PR TITLE
Add Firebase-backed crowdfunding endpoints

### DIFF
--- a/api/_lib/firebaseAdmin.js
+++ b/api/_lib/firebaseAdmin.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+
+let cached = null;
+
+const readJsonFromEnv = (value) => {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    console.warn('[firebase-admin] failed to parse FIREBASE_SERVICE_ACCOUNT_JSON', error.message);
+    return null;
+  }
+};
+
+const readJsonFromBase64 = (value) => {
+  if (!value) return null;
+  try {
+    const decoded = Buffer.from(value, 'base64').toString('utf8');
+    return JSON.parse(decoded);
+  } catch (error) {
+    console.warn('[firebase-admin] failed to parse FIREBASE_SERVICE_ACCOUNT_BASE64', error.message);
+    return null;
+  }
+};
+
+const readJsonFromPath = (filePath) => {
+  if (!filePath) return null;
+  try {
+    if (!fs.existsSync(filePath)) {
+      console.warn(`[firebase-admin] FIREBASE_SERVICE_ACCOUNT_PATH not found: ${filePath}`);
+      return null;
+    }
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    console.warn('[firebase-admin] failed to read FIREBASE_SERVICE_ACCOUNT_PATH', error.message);
+    return null;
+  }
+};
+
+function loadServiceAccount() {
+  return (
+    readJsonFromEnv(process.env.FIREBASE_SERVICE_ACCOUNT_JSON) ||
+    readJsonFromBase64(process.env.FIREBASE_SERVICE_ACCOUNT_BASE64) ||
+    readJsonFromPath(process.env.FIREBASE_SERVICE_ACCOUNT_PATH) ||
+    null
+  );
+}
+
+function getFirebaseAdmin() {
+  if (cached) {
+    return cached;
+  }
+
+  let admin = null;
+  let firestore = null;
+
+  try {
+    // eslint-disable-next-line global-require
+    admin = require('firebase-admin');
+  } catch (error) {
+    console.warn('[firebase-admin] module unavailable', error.message);
+    cached = { admin: null, firestore: null };
+    return cached;
+  }
+
+  try {
+    if (!admin.apps.length) {
+      const serviceAccount = loadServiceAccount();
+      if (serviceAccount) {
+        admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+      } else {
+        admin.initializeApp();
+      }
+    }
+    firestore = typeof admin.firestore === 'function' ? admin.firestore() : null;
+  } catch (error) {
+    console.warn('[firebase-admin] failed to initialize app', error.message);
+    firestore = null;
+  }
+
+  cached = { admin, firestore };
+  return cached;
+}
+
+module.exports = { getFirebaseAdmin };

--- a/api/_lib/squareClient.js
+++ b/api/_lib/squareClient.js
@@ -1,0 +1,54 @@
+let Client = null;
+let Environment = null;
+
+try {
+  const squarePkg = require('square');
+  Client = squarePkg.Client || (squarePkg.default && squarePkg.default.Client) || null;
+  Environment = squarePkg.Environment || (squarePkg.default && squarePkg.default.Environment) || null;
+} catch (error) {
+  console.warn('[square] SDK unavailable', error.message);
+}
+
+let cached = null;
+
+function resolveEnvironmentName() {
+  const raw = (process.env.SQUARE_ENVIRONMENT || 'production').toLowerCase();
+  if (raw === 'sandbox') return 'Sandbox';
+  return 'Production';
+}
+
+function getSquareClient() {
+  if (cached) return cached;
+
+  const accessToken = process.env.SQUARE_ACCESS_TOKEN || '';
+  const locationId = process.env.SQUARE_LOCATION_ID || '';
+  const environmentName = resolveEnvironmentName();
+
+  if (!Client || !accessToken) {
+    cached = { client: null, locationId, environmentName };
+    if (!Client) {
+      console.warn('[square] Client class unavailable; skipping initialization');
+    } else if (!accessToken) {
+      console.warn('[square] access token missing; square client disabled');
+    }
+    return cached;
+  }
+
+  try {
+    const env = (Environment && Environment[environmentName]) || (Environment && Environment.Production) || environmentName;
+    const client = new Client({ accessToken, environment: env });
+    cached = { client, locationId, environmentName };
+    if (process.env.NODE_ENV !== 'production') {
+      const tail = accessToken.slice(-4);
+      // eslint-disable-next-line no-console
+      console.log('[square] client initialized', { environmentName, hasLocation: !!locationId, tokenTail: tail });
+    }
+  } catch (error) {
+    console.warn('[square] failed to initialize client', error.message);
+    cached = { client: null, locationId, environmentName };
+  }
+
+  return cached;
+}
+
+module.exports = { getSquareClient };

--- a/api/crowdfund/checkout.js
+++ b/api/crowdfund/checkout.js
@@ -2,40 +2,21 @@
 // Accepts embedded card payment (Square) for crowdfunding pizzas / pledges.
 // Body: { items: [{ name, price (in cents), quantity, type, pizzaCount }], funderName, token, pizzaQty }
 
-const { Client, Environment } = require('square');
-const ACCESS_TOKEN = process.env.SQUARE_ACCESS_TOKEN;
-const LOCATION_ID = process.env.SQUARE_LOCATION_ID;
-const ENV_NAME = ((process.env.SQUARE_ENVIRONMENT || 'production').toLowerCase() === 'sandbox') ? 'Sandbox' : 'Production';
-
-let sq = null;
-try {
-  if (ACCESS_TOKEN) {
-    const env = Environment[ENV_NAME] || Environment.Production;
-    sq = new Client({ accessToken: ACCESS_TOKEN, environment: env });
-    /* eslint-disable no-console */
-    if (process.env.NODE_ENV !== 'production') {
-      console.log('[crowdfund.checkout] Square client initialized', { env: ENV_NAME, locPresent: !!LOCATION_ID, tokenTail: ACCESS_TOKEN.slice(-4) });
-    }
-    /* eslint-enable no-console */
-  }
-} catch (_) { /* ignore init errors */ }
-
-// Firestore (for updating pizzasSold) — reuse backend server style if available
-let db = null;
-try {
-  const admin = require('firebase-admin');
-  if (!admin.apps.length) {
-    // Expect credentials to already be provisioned via GOOGLE_APPLICATION_CREDENTIALS or env vars.
-    admin.initializeApp();
-  }
-  db = admin.firestore();
-} catch (_) { /* ignore Firestore errors; endpoint will still process payment */ }
+const { getSquareClient } = require('../_lib/squareClient');
+const { getFirebaseAdmin } = require('../_lib/firebaseAdmin');
 
 module.exports = async (req, res) => {
-  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { client: squareClient, locationId } = getSquareClient();
+  const { firestore: db } = getFirebaseAdmin();
+
   try {
-    if (!sq) return res.status(500).json({ error: 'Square not configured' });
-    if (!LOCATION_ID) return res.status(500).json({ error: 'Square location missing' });
+    if (!squareClient) return res.status(500).json({ error: 'Square not configured' });
+    if (!locationId) return res.status(500).json({ error: 'Square location missing' });
 
     const { items, funderName, token, email, phone, notes, notify } = req.body || {};
     if (!token) return res.status(400).json({ error: 'Missing payment token' });
@@ -56,12 +37,12 @@ module.exports = async (req, res) => {
       sourceId: token,
       idempotencyKey,
       amountMoney: { amount: Math.round(lineTotal), currency: 'USD' },
-      locationId: LOCATION_ID,
+      locationId,
       note: noteStr,
       autocomplete: true,
     };
 
-    const resp = await sq.paymentsApi.createPayment(paymentBody);
+    const resp = await squareClient.paymentsApi.createPayment(paymentBody);
     const paymentId = resp.result.payment?.id;
 
     // Update crowdfund totals (best-effort) — count pizzas from items where type === 'pizza'

--- a/api/crowdfund/confirm-payment.js
+++ b/api/crowdfund/confirm-payment.js
@@ -1,0 +1,73 @@
+const { getFirebaseAdmin } = require('../_lib/firebaseAdmin');
+
+const sanitizeName = (value) => {
+  const str = String(value || '').trim();
+  if (!str) return 'Anonymous';
+  return str.slice(0, 120);
+};
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { firestore: db } = getFirebaseAdmin();
+  if (!db) {
+    return res.status(503).json({ error: 'Database not configured on this server.' });
+  }
+
+  const { items = [], funderName, email, phone, notes, notify } = req.body || {};
+  const pizzasInCart = Array.isArray(items)
+    ? items
+        .filter((item) => item && item.type === 'pizza')
+        .reduce((sum, item) => {
+          const count = Number(item.pizzaCount || item.quantity || 0);
+          return sum + (Number.isFinite(count) && count > 0 ? count : 0);
+        }, 0)
+    : 0;
+
+  if (!pizzasInCart) {
+    return res.json({ success: true, message: 'No pizza items to update.' });
+  }
+
+  try {
+    const docRef = db.collection('crowdfund').doc('status');
+    await db.runTransaction(async (transaction) => {
+      const doc = await transaction.get(docRef);
+      const current = doc.exists ? doc.data() || {} : {};
+      const goal = typeof current.goal === 'number' ? current.goal : 1000;
+      const pizzasSold = Number(current.pizzasSold) || 0;
+      const funders = Array.isArray(current.funders) ? current.funders.slice() : [];
+
+      funders.push({
+        name: sanitizeName(funderName),
+        date: new Date().toISOString(),
+        email: email || null,
+        phone: phone || null,
+        notes: notes || null,
+        notify: notify || 'none',
+        pizzas: pizzasInCart,
+      });
+
+      const payload = {
+        goal,
+        pizzasSold: pizzasSold + pizzasInCart,
+        funders,
+      };
+
+      if (doc.exists) {
+        transaction.update(docRef, payload);
+      } else {
+        transaction.set(docRef, payload);
+      }
+    });
+
+    const updatedDoc = await docRef.get();
+    const updatedTotal = updatedDoc.exists ? updatedDoc.data()?.pizzasSold || 0 : 0;
+    return res.json({ success: true, newTotal: updatedTotal });
+  } catch (error) {
+    console.warn('[crowdfund.confirm-payment] failed to persist pizzas', error.message);
+    return res.status(500).json({ error: 'Failed to update database after payment.' });
+  }
+};

--- a/api/crowdfund/contribute.js
+++ b/api/crowdfund/contribute.js
@@ -1,0 +1,60 @@
+const { v4: uuidv4 } = require('uuid');
+const { getSquareClient } = require('../_lib/squareClient');
+
+const DEFAULT_SUCCESS_URL = 'https://localeffortfood.com/crowdfunding?payment=success';
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { client: squareClient, locationId } = getSquareClient();
+  if (!squareClient) {
+    return res.status(500).json({ error: 'Payment provider not configured on this server.' });
+  }
+  if (!locationId) {
+    return res.status(500).json({ error: 'Square location missing' });
+  }
+
+  const { items } = req.body || {};
+  if (!Array.isArray(items) || items.length === 0) {
+    return res.status(400).json({ error: 'Cart is empty.' });
+  }
+
+  const lineItems = items.map((item) => {
+    const quantity = Number(item?.quantity || item?.pizzaCount || 1);
+    const normalizedQuantity = Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+    const priceDollars = Number(item?.price || 0);
+    const amount = Math.round(priceDollars * 100);
+    return {
+      name: item?.name || 'Contribution',
+      quantity: String(normalizedQuantity),
+      basePriceMoney: {
+        amount,
+        currency: 'USD',
+      },
+    };
+  });
+
+  const checkoutOptions = {
+    redirectUrl: process.env.CROWDFUND_PAYMENT_SUCCESS_URL || DEFAULT_SUCCESS_URL,
+    askForShippingAddress: true,
+  };
+
+  try {
+    const response = await squareClient.checkoutApi.createPaymentLink({
+      idempotencyKey: uuidv4(),
+      order: {
+        locationId,
+        lineItems,
+      },
+      checkoutOptions,
+    });
+
+    return res.status(200).json({ url: response.result?.paymentLink?.url || null });
+  } catch (error) {
+    console.warn('[crowdfund.contribute] failed to create payment link', error.message);
+    return res.status(500).json({ error: 'Failed to create payment link.' });
+  }
+};

--- a/api/crowdfund/pizza-feedback.js
+++ b/api/crowdfund/pizza-feedback.js
@@ -1,0 +1,90 @@
+const { getFirebaseAdmin } = require('../_lib/firebaseAdmin');
+
+const FEEDBACK_COLLECTION = 'crowdfund_feedback';
+
+const sanitizeName = (value) => {
+  const str = String(value || '').replace(/\s+/g, ' ').trim();
+  return str.slice(0, 120);
+};
+
+const sanitizeMessage = (value) => {
+  const str = String(value || '').replace(/\r/g, '').trim();
+  return str.slice(0, 600);
+};
+
+const mapFeedbackDoc = (doc) => {
+  if (!doc) return null;
+  const data = typeof doc.data === 'function' ? doc.data() : doc;
+  if (!data) return null;
+  const message = sanitizeMessage(data.message);
+  if (!message) return null;
+  return {
+    id: doc.id || data.id || `feedback-${Date.now()}`,
+    name: sanitizeName(data.name) || 'Anonymous pizza fan',
+    message,
+    createdAt: data.createdAt || null,
+  };
+};
+
+module.exports = async (req, res) => {
+  const { firestore: db } = getFirebaseAdmin();
+
+  if (req.method === 'GET') {
+    if (!db) {
+      return res.status(503).json({ error: 'Feedback storage unavailable' });
+    }
+
+    let limit = parseInt(req.query?.limit, 10);
+    if (!Number.isFinite(limit) || limit <= 0) limit = 8;
+    limit = Math.min(limit, 20);
+
+    try {
+      const snapshot = await db
+        .collection(FEEDBACK_COLLECTION)
+        .orderBy('createdAtMs', 'desc')
+        .limit(limit)
+        .get();
+
+      const entries = Array.isArray(snapshot?.docs)
+        ? snapshot.docs.map((doc) => mapFeedbackDoc({ id: doc.id, data: () => doc.data() })).filter(Boolean)
+        : [];
+
+      return res.status(200).json({ entries });
+    } catch (error) {
+      console.warn('[crowdfund.pizza-feedback] list error', error.message);
+      return res.status(500).json({ error: 'Failed to load pizza feedback.' });
+    }
+  }
+
+  if (req.method === 'POST') {
+    if (!db) {
+      return res.status(503).json({ error: 'Feedback storage unavailable' });
+    }
+
+    const name = sanitizeName(req.body?.name);
+    const message = sanitizeMessage(req.body?.message);
+
+    if (!message) {
+      return res.status(400).json({ error: 'Please share a quick note about the pizza.' });
+    }
+
+    const entry = {
+      name: name || 'Anonymous pizza fan',
+      message,
+      createdAt: new Date().toISOString(),
+      createdAtMs: Date.now(),
+      source: 'web',
+    };
+
+    try {
+      const docRef = await db.collection(FEEDBACK_COLLECTION).add(entry);
+      return res.status(200).json({ entry: { ...entry, id: docRef.id || `feedback-${entry.createdAtMs}` } });
+    } catch (error) {
+      console.warn('[crowdfund.pizza-feedback] write error', error.message);
+      return res.status(500).json({ error: 'Failed to save pizza feedback.' });
+    }
+  }
+
+  res.setHeader('Allow', 'GET, POST');
+  return res.status(405).json({ error: 'Method not allowed' });
+};

--- a/api/crowdfund/status.js
+++ b/api/crowdfund/status.js
@@ -1,0 +1,35 @@
+const { getFirebaseAdmin } = require('../_lib/firebaseAdmin');
+
+const FALLBACK_STATUS = {
+  goal: 1000,
+  pizzasSold: 0,
+  funders: [],
+  source: 'fallback',
+};
+
+module.exports = async (req, res) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { firestore: db } = getFirebaseAdmin();
+  if (!db) {
+    return res.status(200).json(FALLBACK_STATUS);
+  }
+
+  try {
+    const docRef = db.collection('crowdfund').doc('status');
+    const doc = await docRef.get();
+    if (!doc.exists) {
+      const defaultData = { goal: 1000, pizzasSold: 0, funders: [] };
+      await docRef.set(defaultData);
+      return res.status(200).json(defaultData);
+    }
+    const data = doc.data() || {};
+    return res.status(200).json(data);
+  } catch (error) {
+    console.warn('[crowdfund.status] failed to load status', error.message);
+    return res.status(200).json(FALLBACK_STATUS);
+  }
+};


### PR DESCRIPTION
## Summary
- add a reusable Firebase Admin helper so serverless functions can authenticate with Firestore using env-provided service accounts
- centralize Square client initialization and reuse it across crowdfunding endpoints
- implement the missing Vercel API routes for crowdfunding status, payment confirmation, contribute, and pizza feedback to persist metrics in Firestore

## Testing
- pnpm lint *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5cc283b7883219147da01e0d38f4d