### PR TITLE
Add black outline to header logo

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -39,7 +39,7 @@ export const Header = () => {
           <motion.img
             src={logo}
             alt="Local Effort Logo"
-            className="h-7 w-auto"
+            className="h-7 w-auto rounded-md border border-black"
             whileHover={{ scale: 1.03 }}
             transition={{ type: 'spring', stiffness: 300, damping: 20 }}
           />


### PR DESCRIPTION
## Summary
- add a black border to the header logo to give it a defined outline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5d959889c83219d781a73cd9623f8