### PR TITLE
Implement live crowdfunding pipeline integration

### DIFF
--- a/api/crowdfunding/summary.ts
+++ b/api/crowdfunding/summary.ts
@@ -1,0 +1,50 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { db } from '../../packages/lib/firebaseAdmin';
+
+type Req = IncomingMessage & { method?: string };
+type Res = ServerResponse & {
+  status: (code: number) => Res;
+  json: (body: unknown) => void;
+  setHeader: (name: string, value: string) => void;
+};
+
+function withHelpers(res: ServerResponse): Res {
+  const enhanced = res as Res;
+  enhanced.status = function status(code: number) {
+    res.statusCode = code;
+    return enhanced;
+  };
+  enhanced.json = function json(body: unknown) {
+    const payload = JSON.stringify(body);
+    if (!res.getHeader('Content-Type')) {
+      res.setHeader('Content-Type', 'application/json');
+    }
+    res.end(payload);
+  };
+  return enhanced;
+}
+
+export default async function handler(request: Req, response: ServerResponse): Promise<void> {
+  const req = request;
+  const res = withHelpers(response);
+
+  if (req.method && req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ ok: false, error: 'method-not-allowed' });
+    return;
+  }
+
+  try {
+    const snapshot = await db.collection('aggregates').doc('crowdfunding').get();
+    const data = snapshot.exists ? snapshot.data() ?? {} : {};
+    res.setHeader('Cache-Control', 'no-store');
+    res.status(200).json({
+      pizzas: typeof data.pizzas === 'number' ? data.pizzas : 0,
+      backers: typeof data.backers === 'number' ? data.backers : 0,
+      updatedAt: data.updatedAt ?? null,
+    });
+  } catch (error) {
+    console.error('[crowdfunding.summary] failed to load aggregate', error);
+    res.status(500).json({ ok: false, error: 'internal-error' });
+  }
+}

--- a/api/feedback/index.ts
+++ b/api/feedback/index.ts
@@ -1,0 +1,131 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { URL } from 'node:url';
+import { db } from '../../packages/lib/firebaseAdmin';
+
+type Req = IncomingMessage & { method?: string; body?: any; url?: string };
+type Res = ServerResponse & {
+  status: (code: number) => Res;
+  json: (body: unknown) => void;
+  setHeader: (name: string, value: string) => void;
+};
+
+const MAX_COMMENT_LENGTH = 2000;
+
+function withHelpers(res: ServerResponse): Res {
+  const enhanced = res as Res;
+  enhanced.status = function status(code: number) {
+    res.statusCode = code;
+    return enhanced;
+  };
+  enhanced.json = function json(body: unknown) {
+    const payload = JSON.stringify(body);
+    if (!res.getHeader('Content-Type')) {
+      res.setHeader('Content-Type', 'application/json');
+    }
+    res.end(payload);
+  };
+  return enhanced;
+}
+
+function sanitizeString(value: unknown, limit: number): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.replace(/\r/g, '').trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, limit);
+}
+
+function parseJsonBody(req: Req): any {
+  if (req.body !== undefined) {
+    return req.body;
+  }
+  return undefined;
+}
+
+export default async function handler(request: Req, response: ServerResponse): Promise<void> {
+  const req = request;
+  const res = withHelpers(response);
+
+  if (!req.method) {
+    res.status(400).json({ ok: false, error: 'invalid-request' });
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const body = parseJsonBody(req) ?? {};
+    const rating = Number(body.rating);
+    const comment = sanitizeString(body.comment, MAX_COMMENT_LENGTH);
+    const customerId = typeof body.customerId === 'string' && body.customerId.trim() ? body.customerId.trim() : null;
+    const orderId = typeof body.orderId === 'string' && body.orderId.trim() ? body.orderId.trim() : null;
+
+    if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+      res.status(400).json({ ok: false, error: 'invalid-rating' });
+      return;
+    }
+
+    if (!comment) {
+      res.status(400).json({ ok: false, error: 'missing-comment' });
+      return;
+    }
+
+    try {
+      const ref = db.collection('feedback').doc();
+      const doc = {
+        rating,
+        comment,
+        customerId,
+        orderId,
+        createdAt: new Date(),
+      };
+      await ref.set(doc);
+      res.status(200).json({ ok: true, id: ref.id });
+    } catch (error) {
+      console.error('[feedback.post] failed to persist feedback', error);
+      res.status(500).json({ ok: false, error: 'internal-error' });
+    }
+    return;
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const sinceParam = (() => {
+        if (!req.url) return null;
+        try {
+          const url = new URL(req.url, 'http://localhost');
+          return url.searchParams.get('since');
+        } catch (error) {
+          return null;
+        }
+      })();
+      const limitParam = (() => {
+        if (!req.url) return null;
+        try {
+          const url = new URL(req.url, 'http://localhost');
+          return url.searchParams.get('limit');
+        } catch (error) {
+          return null;
+        }
+      })();
+
+      const since = sinceParam ? new Date(sinceParam) : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      const limitValue = limitParam ? Number(limitParam) : 200;
+      const limit = Number.isFinite(limitValue) ? Math.min(Math.max(limitValue, 1), 500) : 200;
+
+      const snapshot = await db
+        .collection('feedback')
+        .where('createdAt', '>=', since)
+        .orderBy('createdAt', 'desc')
+        .limit(limit)
+        .get();
+
+      const items = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+      res.status(200).json({ ok: true, items });
+    } catch (error) {
+      console.error('[feedback.get] failed to load feedback', error);
+      res.status(500).json({ ok: false, error: 'internal-error' });
+    }
+    return;
+  }
+
+  res.setHeader('Allow', 'GET, POST');
+  res.status(405).json({ ok: false, error: 'method-not-allowed' });
+}

--- a/api/square/webhook.ts
+++ b/api/square/webhook.ts
@@ -1,0 +1,234 @@
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'node:http';
+import crypto from 'node:crypto';
+import { db as defaultDb } from '../../packages/lib/firebaseAdmin';
+
+type Req = IncomingMessage & {
+  method?: string;
+  headers: IncomingHttpHeaders;
+  body?: unknown;
+  rawBody?: Buffer | string;
+};
+
+type Res = ServerResponse & {
+  status: (code: number) => Res;
+  json: (body: unknown) => void;
+  setHeader: (name: string, value: string) => void;
+};
+
+type FirestoreLike = FirebaseFirestore.Firestore;
+
+type PaymentObject = {
+  id: string;
+  status?: string;
+  customer_id?: string | null;
+  order?: {
+    line_items?: Array<{
+      name?: string | null;
+      catalog_object_id?: string | null;
+      quantity?: string | number | null;
+    }>;
+  };
+  amount_money?: {
+    amount?: number | string | null;
+  };
+};
+
+export const config = { api: { bodyParser: false } };
+
+function withHelpers(res: ServerResponse): Res {
+  const enhanced = res as Res;
+  enhanced.status = function status(code: number) {
+    res.statusCode = code;
+    return enhanced;
+  };
+  enhanced.json = function json(body: unknown) {
+    const payload = JSON.stringify(body);
+    if (!res.getHeader('Content-Type')) {
+      res.setHeader('Content-Type', 'application/json');
+    }
+    res.end(payload);
+  };
+  return enhanced;
+}
+
+async function readRawBody(req: Req): Promise<Buffer> {
+  if (Buffer.isBuffer(req.rawBody)) {
+    return req.rawBody;
+  }
+  if (typeof req.rawBody === 'string') {
+    return Buffer.from(req.rawBody);
+  }
+  if (Buffer.isBuffer(req.body)) {
+    return req.body;
+  }
+  if (typeof req.body === 'string') {
+    return Buffer.from(req.body);
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+function timingSafeEqual(a: Buffer, b: Buffer): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+}
+
+export function verifySquareSignature(rawBody: Buffer, signature: string): boolean {
+  const sigKey = process.env.SQUARE_WEBHOOK_SIGNATURE_KEY;
+  const notificationUrl = process.env.SQUARE_WEBHOOK_NOTIFICATION_URL;
+  if (!sigKey || !notificationUrl) {
+    console.error('[square.webhook] missing signature configuration');
+    return false;
+  }
+  const hmac = crypto.createHmac('sha256', sigKey);
+  hmac.update(notificationUrl + rawBody.toString('utf8'));
+  const digest = hmac.digest('base64');
+  const provided = Buffer.from(signature);
+  const expected = Buffer.from(digest);
+  return timingSafeEqual(provided, expected);
+}
+
+function parsePizzaQuantity(payment: PaymentObject): number {
+  const items = payment.order?.line_items ?? [];
+  return items
+    .filter((item) => {
+      const name = item.name ?? '';
+      const catalogId = item.catalog_object_id ?? '';
+      return /pizza/i.test(name) || /pizza/i.test(catalogId);
+    })
+    .reduce((sum, item) => {
+      const quantityRaw = item.quantity;
+      const quantity = typeof quantityRaw === 'string' ? Number(quantityRaw) : Number(quantityRaw ?? 0);
+      return sum + (Number.isFinite(quantity) ? quantity : 0);
+    }, 0);
+}
+
+export async function applyCompletedPayment(payment: PaymentObject, options: { db?: FirestoreLike } = {}): Promise<void> {
+  const firestore = options.db ?? defaultDb;
+  if (!firestore) {
+    throw new Error('Firestore unavailable');
+  }
+
+  const paymentId = payment.id;
+  const customerId = payment.customer_id ?? null;
+  const qty = parsePizzaQuantity(payment);
+  const amount = Number(payment.amount_money?.amount ?? 0);
+
+  await firestore.runTransaction(async (tx) => {
+    const ordersRef = firestore.collection('orders').doc(paymentId);
+    const existingOrder = await tx.get(ordersRef);
+    if (existingOrder.exists) {
+      return;
+    }
+
+    tx.set(ordersRef, {
+      createdAt: new Date(),
+      squarePaymentId: paymentId,
+      customerId,
+      item: 'pizza',
+      qty,
+      amount,
+      status: 'PAID',
+      source: 'square',
+    });
+
+    let backerIncrement = 0;
+    if (customerId) {
+      const backerRef = firestore.collection('backers').doc(customerId);
+      const backerSnap = await tx.get(backerRef);
+      if (!backerSnap.exists) {
+        backerIncrement = 1;
+        tx.set(backerRef, {
+          firstSeenAt: new Date(),
+          ordersCount: 1,
+          amountTotal: amount,
+        });
+      } else {
+        const data = backerSnap.data() ?? {};
+        tx.update(backerRef, {
+          ordersCount: Number(data.ordersCount ?? 0) + 1,
+          amountTotal: Number(data.amountTotal ?? 0) + amount,
+        });
+      }
+    }
+
+    const aggRef = firestore.collection('aggregates').doc('crowdfunding');
+    const aggSnap = await tx.get(aggRef);
+    const base = aggSnap.exists ? aggSnap.data() ?? {} : {};
+    const nextPizzas = Number(base.pizzas ?? 0) + qty;
+    const nextBackers = Number(base.backers ?? 0) + backerIncrement;
+    tx.set(
+      aggRef,
+      {
+        pizzas: nextPizzas,
+        backers: nextBackers,
+        updatedAt: new Date(),
+      },
+      { merge: true },
+    );
+  });
+
+  console.info('[square.webhook] processed payment', {
+    id: paymentId,
+    customerId,
+    qty,
+    amount,
+  });
+}
+
+export default async function handler(request: Req, response: ServerResponse): Promise<void> {
+  const req = request;
+  const res = withHelpers(response);
+
+  if (req.method && req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ ok: false, error: 'method-not-allowed' });
+    return;
+  }
+
+  try {
+    const signatureHeader = req.headers['x-square-hmacsha256-signature'];
+    const signature = Array.isArray(signatureHeader) ? signatureHeader[0] : signatureHeader;
+    if (!signature) {
+      res.status(400).json({ ok: false, error: 'missing-signature' });
+      return;
+    }
+
+    const rawBody = await readRawBody(req);
+    if (!verifySquareSignature(rawBody, signature)) {
+      res.status(400).json({ ok: false, error: 'invalid-signature' });
+      return;
+    }
+
+    const payload = JSON.parse(rawBody.toString('utf8'));
+    const eventType = payload?.type ?? payload?.event_type;
+    if (!eventType || !String(eventType).includes('payment')) {
+      res.status(200).json({ ok: true, ignored: true });
+      return;
+    }
+
+    const payment: PaymentObject | undefined = payload?.data?.object?.payment;
+    if (!payment || !payment.id) {
+      res.status(200).json({ ok: true, ignored: true });
+      return;
+    }
+
+    const status = (payment.status || '').toUpperCase();
+    if (status !== 'COMPLETED') {
+      res.status(200).json({ ok: true, ignored: true });
+      return;
+    }
+
+    await applyCompletedPayment(payment);
+
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    console.error('[square.webhook] handler error', error);
+    res.status(500).json({ ok: false, error: 'internal-error' });
+  }
+}

--- a/docs/crowdfunding-pipeline.md
+++ b/docs/crowdfunding-pipeline.md
@@ -1,0 +1,65 @@
+# Crowdfunding pipeline overview
+
+This document summarizes how Square payments flow into Firestore and surface on the `/crowdfunding` page.
+
+## Data flow
+
+1. **Square webhook** (`/api/square/webhook`)
+   - Verifies the Square HMAC signature using `SQUARE_WEBHOOK_SIGNATURE_KEY` and `SQUARE_WEBHOOK_NOTIFICATION_URL`.
+   - Ignores non-payment events and payments that are not `COMPLETED`.
+   - Extracts pizza line-item quantity and total amount, then runs a Firestore transaction that:
+     - Writes a new `orders/{paymentId}` document.
+     - Upserts `backers/{customerId}` with aggregated counts and totals.
+     - Updates `aggregates/crowdfunding` totals (`pizzas`, `backers`, `updatedAt`).
+   - Duplicate webhook deliveries are ignored via the `orders/{paymentId}` existence check.
+
+2. **Crowdfunding summary API** (`/api/crowdfunding/summary`)
+   - Returns the latest `pizzas`, `backers`, and `updatedAt` fields from `aggregates/crowdfunding`.
+   - Sets `Cache-Control: no-store` to avoid CDN caching.
+
+3. **Crowdfunding page** (`src/pages/CrowdfundingPage.jsx`)
+   - Uses `swr` to fetch `/api/crowdfunding/summary` on mount and every 30 seconds.
+   - Merges live totals with Sanity baseline data for display resilience.
+
+4. **Feedback API** (`/api/feedback`)
+   - `POST` validates a 1–5 `rating` and up to 2000-character `comment`, then writes to `feedback/{docId}`.
+   - `GET` returns recent feedback since a timestamp (defaults to the last 7 days).
+   - The crowdfunding page submits ratings and loads recent comments from this endpoint.
+
+5. **Firestore rules** (`firestore.rules`)
+   - Allow public read access only to `aggregates/crowdfunding`.
+   - Lock down all other collections (including `feedback`) for server-side access via the Admin SDK.
+
+## Backfill script
+
+`scripts/backfillSquare.ts` iterates through the Square Payments API and reuses `applyCompletedPayment` to reconcile historical transactions. Provide `SQUARE_ACCESS_TOKEN`, `SQUARE_ENV`, and Firebase Admin credentials, then run with `ts-node` or compile via `tsc`.
+
+## Environment variables
+
+Set the following (matching client/server project IDs):
+
+```
+NEXT_PUBLIC_FIREBASE_API_KEY=...
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=...
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=...
+NEXT_PUBLIC_FIREBASE_APP_ID=...
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=...
+FIREBASE_PROJECT_ID=...
+FIREBASE_CLIENT_EMAIL=...
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+SQUARE_ENV=production
+SQUARE_ACCESS_TOKEN=EAAA...
+SQUARE_WEBHOOK_SIGNATURE_KEY=...
+SQUARE_WEBHOOK_NOTIFICATION_URL=https://<domain>/api/square/webhook
+APP_ENV=production
+```
+
+Ensure `FIREBASE_PROJECT_ID` equals `NEXT_PUBLIC_FIREBASE_PROJECT_ID` to prevent mismatches.
+
+## Testing checklist
+
+- `POST /api/square/webhook` with a valid signature updates `orders`, `backers`, and `aggregates/crowdfunding` once.
+- Replaying the same webhook leaves totals unchanged.
+- `GET /api/crowdfunding/summary` reflects the latest aggregate counts.
+- `POST /api/feedback` accepts ratings 1–5 and truncates comments at 2000 characters.
+- `/crowdfunding` shows live totals within a few seconds of a new payment.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,18 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /aggregates/crowdfunding {
+      allow get, list: if true;
+      allow create, update, delete: if false;
+    }
+
+    match /feedback/{docId} {
+      allow read: if false;
+      allow write: if false;
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "framer-motion": "^12.23.12",
     "jose": "^6.1.0",
     "lucide-react": "^0.451.0",
+    "node-fetch": "^3.3.2",
     "pino": "^9.4.0",
     "pino-http": "^10.1.0",
     "prop-types": "^15.8.1",
@@ -42,6 +43,7 @@
     "react-router-dom": "^6.25.1",
     "recharts": "^2.10.3",
     "square": "^37.0.0",
+    "swr": "^2.3.0",
     "tailwind-merge": "^2.5.2",
     "web-push": "^3.6.6"
   },

--- a/packages/lib/firebaseAdmin.ts
+++ b/packages/lib/firebaseAdmin.ts
@@ -1,0 +1,23 @@
+import { cert, getApps, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+const privateKey = process.env.FIREBASE_PRIVATE_KEY;
+
+if (!projectId || !clientEmail || !privateKey) {
+  throw new Error('Missing Firebase Admin environment variables.');
+}
+
+const app =
+  getApps()[0] ??
+  initializeApp({
+    credential: cert({
+      projectId,
+      clientEmail,
+      privateKey: privateKey.replace(/\\n/g, '\n'),
+    }),
+    projectId,
+  });
+
+export const db = getFirestore(app);

--- a/packages/lib/firebaseClient.ts
+++ b/packages/lib/firebaseClient.ts
@@ -1,0 +1,11 @@
+import { initializeApp, getApps } from 'firebase/app';
+
+export const firebaseApp =
+  getApps()[0] ??
+  initializeApp({
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       lucide-react:
         specifier: ^0.451.0
         version: 0.451.0(react@18.2.0)
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
       pino:
         specifier: ^9.4.0
         version: 9.4.0
@@ -122,6 +125,9 @@ importers:
       square:
         specifier: ^37.0.0
         version: 37.1.0
+      swr:
+        specifier: ^2.3.0
+        version: 2.3.6(react@18.2.0)
       tailwind-merge:
         specifier: ^2.5.2
         version: 2.5.2
@@ -3925,6 +3931,10 @@ packages:
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -4039,6 +4049,10 @@ packages:
   dependency-graph@0.11.0:
     resolution: {integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==}
     engines: {node: '>= 0.6.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -4577,6 +4591,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4655,6 +4673,10 @@ packages:
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   formidable@2.1.5:
     resolution: {integrity: sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==}
@@ -5839,6 +5861,11 @@ packages:
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch-h2@2.3.0:
     resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==}
     engines: {node: 4.x || >=6.0.0}
@@ -5851,6 +5878,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -7095,6 +7126,11 @@ packages:
     resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
     hasBin: true
 
+  swr@2.3.6:
+    resolution: {integrity: sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -7627,6 +7663,10 @@ packages:
     resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
     engines: {node: '>= 16'}
     hasBin: true
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
@@ -11383,6 +11423,8 @@ snapshots:
 
   data-uri-to-buffer@2.0.2: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -11491,6 +11533,8 @@ snapshots:
   depd@2.0.0: {}
 
   dependency-graph@0.11.0: {}
+
+  dequal@2.0.3: {}
 
   destroy@1.2.0: {}
 
@@ -12313,6 +12357,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -12466,6 +12515,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   formidable@2.1.5:
     dependencies:
@@ -13716,6 +13769,8 @@ snapshots:
 
   node-abort-controller@3.1.1: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch-h2@2.3.0:
     dependencies:
       http2-client: 1.3.5
@@ -13723,6 +13778,12 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-forge@1.3.1: {}
 
@@ -15194,6 +15255,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  swr@2.3.6(react@18.2.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 18.2.0
+      use-sync-external-store: 1.6.0(react@18.2.0)
+
   synckit@0.11.11:
     dependencies:
       '@pkgr/core': 0.2.9
@@ -15882,6 +15949,8 @@ snapshots:
       minimist: 1.2.8
     transitivePeerDependencies:
       - supports-color
+
+  web-streams-polyfill@3.3.3: {}
 
   web-vitals@4.2.4: {}
 

--- a/scripts/backfillSquare.ts
+++ b/scripts/backfillSquare.ts
@@ -1,0 +1,63 @@
+import fetch from 'node-fetch';
+import { applyCompletedPayment } from '../api/square/webhook';
+import { db } from '../packages/lib/firebaseAdmin';
+
+const BASE_URL = process.env.SQUARE_ENV === 'production'
+  ? 'https://connect.squareup.com'
+  : 'https://connect.squareupsandbox.com';
+
+async function listPayments(cursor?: string) {
+  const url = new URL('/v2/payments', BASE_URL);
+  if (cursor) {
+    url.searchParams.set('cursor', cursor);
+  }
+  url.searchParams.set('sort_order', 'DESC');
+  url.searchParams.set('limit', '100');
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Square API error: ${res.status} ${text}`);
+  }
+
+  return res.json();
+}
+
+async function backfill() {
+  if (!process.env.SQUARE_ACCESS_TOKEN) {
+    throw new Error('SQUARE_ACCESS_TOKEN missing');
+  }
+
+  console.info('[backfillSquare] starting backfill');
+
+  let cursor: string | undefined;
+  let processed = 0;
+
+  do {
+    const batch = await listPayments(cursor);
+    const payments = Array.isArray(batch?.payments) ? batch.payments : [];
+
+    for (const payment of payments) {
+      if (!payment || !payment.id) continue;
+      const status = String(payment.status || '').toUpperCase();
+      if (status !== 'COMPLETED') continue;
+      await applyCompletedPayment(payment, { db });
+      processed += 1;
+    }
+
+    cursor = batch?.cursor || undefined;
+  } while (cursor);
+
+  console.info('[backfillSquare] finished', { processed });
+}
+
+backfill().catch((error) => {
+  console.error('[backfillSquare] failed', error);
+  process.exitCode = 1;
+});

--- a/server.js
+++ b/server.js
@@ -1,10 +1,24 @@
 const path = require('path');
+
+try {
+  require('ts-node/register/transpile-only');
+} catch (err) {
+  try {
+    require('ts-node/register');
+  } catch (innerErr) {
+    console.warn('[server] ts-node unavailable, TypeScript API routes may not load');
+  }
+}
+
 require('dotenv').config({ path: path.resolve(__dirname, '.env') });
 
 const express = require('express');
 const cloudinary = require('cloudinary');
 const logger = require('./logger');
 const crowdfundCheckoutHandler = require('./api/crowdfund/checkout');
+const squareWebhookHandler = require('./api/square/webhook').default;
+const crowdfundingSummaryHandler = require('./api/crowdfunding/summary').default;
+const feedbackHandler = require('./api/feedback/index').default;
 // Sentry (backend light server)
 let Sentry;
 try {
@@ -24,6 +38,16 @@ try {
 }
 
 const app = express();
+
+// Webhook needs the raw body for signature verification
+app.post('/api/square/webhook', express.raw({ type: '*/*', limit: '2mb' }), async (req, res, next) => {
+  try {
+    await squareWebhookHandler(req, res);
+  } catch (err) {
+    console.error('[server] square webhook error', err);
+    next(err);
+  }
+});
 
 // Parse JSON bodies for API routes
 app.use(express.json({ limit: '2mb' }));
@@ -97,6 +121,24 @@ app.all('/api/crowdfund/checkout', async (req, res, next) => {
     await crowdfundCheckoutHandler(req, res);
   } catch (err) {
     logger.error({ err, method: req.method }, 'crowdfund checkout handler failed');
+    next(err);
+  }
+});
+
+app.all('/api/crowdfunding/summary', async (req, res, next) => {
+  try {
+    await crowdfundingSummaryHandler(req, res);
+  } catch (err) {
+    console.error('[server] crowdfunding summary error', err);
+    next(err);
+  }
+});
+
+app.all('/api/feedback', async (req, res, next) => {
+  try {
+    await feedbackHandler(req, res);
+  } catch (err) {
+    console.error('[server] feedback handler error', err);
     next(err);
   }
 });

--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -1,5 +1,6 @@
 // ...existing code...
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useSWR from 'swr';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet-async';
 import { PortableText } from '@portabletext/react';
@@ -15,6 +16,14 @@ import PrioritiesPie from '../components/crowdfunding/PrioritiesPie.jsx';
 import { createPortableTextComponents } from '../utils/portableTextComponents';
 import { cn } from '../lib/utils';
 import { useToast } from '../components/common/ToastProvider';
+
+const summaryFetcher = async (url) => {
+  const response = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return response.json();
+};
 
 // --- Sanity Image URL Builder Setup (kept for future use if dynamic hero image restored) ---
 // const builder = imageUrlBuilder(sanityClient);
@@ -163,7 +172,7 @@ const CrowdfundingPage = () => {
   const [subscribeStatus, setSubscribeStatus] = useState('idle'); // idle | loading | success | error
   const [subscribeMessage, setSubscribeMessage] = useState('');
   const [rewardPreference, setRewardPreference] = useState(REWARD_PREFERENCE_OPTIONS[0].value);
-  const [feedbackName, setFeedbackName] = useState('');
+  const [feedbackRating, setFeedbackRating] = useState(5);
   const [feedbackMessage, setFeedbackMessage] = useState('');
   const [feedbackNotice, setFeedbackNotice] = useState('');
   const [feedbackStatus, setFeedbackStatus] = useState('idle'); // idle | error | success
@@ -177,8 +186,18 @@ const CrowdfundingPage = () => {
   const [galleryError, setGalleryError] = useState('');
   const galleryLoadedRef = React.useRef(false);
   const [eventModal, setEventModal] = useState(null);
-  const [liveStatus, setLiveStatus] = useState({ goal: null, pizzasSold: null, backers: null });
-  const [statusRefreshError, setStatusRefreshError] = useState(false);
+
+  const {
+    data: summaryData,
+    error: summaryError,
+  } = useSWR('/api/crowdfunding/summary', summaryFetcher, {
+    refreshInterval: 30000,
+    revalidateOnFocus: true,
+  });
+  const summaryPizzas = Number(summaryData?.pizzas);
+  const summaryBackers = Number(summaryData?.backers);
+  const summaryGoal = Number(summaryData?.goal);
+  const statusRefreshError = Boolean(summaryError);
 
   useEffect(() => {
     if (activeTab === 'gallery' && !galleryLoadedRef.current) {
@@ -218,19 +237,25 @@ const CrowdfundingPage = () => {
 
     const loadFeedback = async () => {
       try {
-        const res = await fetch('/api/crowdfund/pizza-feedback?limit=8');
+        const res = await fetch('/api/feedback?limit=8', { headers: { Accept: 'application/json' } });
         let data = null;
         try {
           data = await res.json();
         } catch (_) {
           data = null;
         }
-        if (!res.ok) {
+        if (!res.ok || (data && data.ok === false)) {
           const message = (data && data.error) || 'Unable to reach the pizza feedback service right now.';
           throw new Error(message);
         }
-        const entries = Array.isArray(data?.entries)
-          ? data.entries.filter((entry) => entry && entry.message)
+        const entries = Array.isArray(data?.items)
+          ? data.items
+              .map((entry) => ({
+                id: entry.id || `feedback-${entry.createdAt || Date.now()}`,
+                rating: Number(entry.rating),
+                comment: typeof entry.comment === 'string' ? entry.comment.trim() : '',
+              }))
+              .filter((entry) => entry.comment)
           : [];
         if (!cancelled) {
           setFeedbackEntries(entries);
@@ -339,55 +364,6 @@ const CrowdfundingPage = () => {
     };
 
     doFetch();
-  }, []);
-
-  useEffect(() => {
-    let ignore = false;
-
-    const fetchStatus = async () => {
-      try {
-        const response = await fetch('/api/crowdfund/status', {
-          headers: { Accept: 'application/json' },
-        });
-        if (!response.ok) {
-          throw new Error(`Request failed with status ${response.status}`);
-        }
-        const data = await response.json();
-        if (ignore) return;
-
-        const toNumber = (value) => {
-          if (typeof value === 'number' && Number.isFinite(value)) return value;
-          if (typeof value === 'string') {
-            const parsed = Number(value);
-            return Number.isFinite(parsed) ? parsed : null;
-          }
-          return null;
-        };
-
-        const goalValue = toNumber(data.goal);
-        const pizzasValue = toNumber(data.pizzasSold);
-        const backerCount = Array.isArray(data.funders)
-          ? data.funders.length
-          : toNumber(data.backers);
-
-        setLiveStatus({
-          goal: goalValue,
-          pizzasSold: pizzasValue,
-          backers: typeof backerCount === 'number' && backerCount >= 0 ? backerCount : null,
-        });
-        setStatusRefreshError(false);
-      } catch (error) {
-        if (ignore) return;
-        console.warn('[crowdfunding] failed to fetch live crowdfund status', error);
-        setStatusRefreshError(true);
-      }
-    };
-
-    fetchStatus();
-
-    return () => {
-      ignore = true;
-    };
   }, []);
 
   // Derive reward tiers safely for hooks below
@@ -508,12 +484,18 @@ const CrowdfundingPage = () => {
       event.preventDefault();
       if (feedbackSubmitting) return;
 
-      const name = feedbackName.trim();
       const message = feedbackMessage.trim();
+      const ratingValue = Number(feedbackRating);
 
       if (!message) {
         setFeedbackStatus('error');
         setFeedbackNotice('Please share a quick note about the pizza.');
+        return;
+      }
+
+      if (!Number.isInteger(ratingValue) || ratingValue < 1 || ratingValue > 5) {
+        setFeedbackStatus('error');
+        setFeedbackNotice('Please choose how much you loved the pizza.');
         return;
       }
 
@@ -522,10 +504,10 @@ const CrowdfundingPage = () => {
       setFeedbackSubmitting(true);
 
       try {
-        const res = await fetch('/api/crowdfund/pizza-feedback', {
+        const res = await fetch('/api/feedback', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ name, message }),
+          body: JSON.stringify({ rating: ratingValue, comment: message }),
         });
 
         let data = null;
@@ -535,26 +517,16 @@ const CrowdfundingPage = () => {
           data = null;
         }
 
-        if (!res.ok) {
+        if (!res.ok || (data && data.ok === false)) {
           const messageText = (data && data.error) || 'We had trouble saving your pizza note. Please try again.';
           throw new Error(messageText);
         }
 
-        const entryFromServer =
-          data && data.entry && data.entry.message
-            ? {
-                id: data.entry.id || `feedback-${Date.now()}`,
-                name: data.entry.name || 'Anonymous pizza fan',
-                message: data.entry.message,
-              }
-            : null;
-
-        const nextEntry =
-          entryFromServer || {
-            id: `feedback-${Date.now()}`,
-            name: name || 'Anonymous pizza fan',
-            message,
-          };
+        const nextEntry = {
+          id: (data && data.id) || `feedback-${Date.now()}`,
+          rating: ratingValue,
+          comment: message,
+        };
 
         setFeedbackEntries((prev) => {
           const safePrev = Array.isArray(prev)
@@ -563,8 +535,8 @@ const CrowdfundingPage = () => {
           return [nextEntry, ...safePrev].slice(0, 8);
         });
         setFeedbackFetchError('');
-        setFeedbackName('');
         setFeedbackMessage('');
+        setFeedbackRating(5);
         setFeedbackStatus('success');
         setFeedbackNotice('Thanks for spreading the pizza love!');
       } catch (err) {
@@ -574,7 +546,7 @@ const CrowdfundingPage = () => {
         setFeedbackSubmitting(false);
       }
     },
-    [feedbackMessage, feedbackName, feedbackSubmitting]
+    [feedbackMessage, feedbackRating, feedbackSubmitting]
   );
 
   // Destructure frequently used fields from campaign data (safe even if null)
@@ -982,14 +954,14 @@ const CrowdfundingPage = () => {
     }
     return 1000;
   })();
-  const pizzasSold = Number.isFinite(liveStatus.pizzasSold) && liveStatus.pizzasSold >= 0
-    ? Math.max(liveStatus.pizzasSold, basePizzasSold)
+  const pizzasSold = Number.isFinite(summaryPizzas) && summaryPizzas >= 0
+    ? Math.max(summaryPizzas, basePizzasSold)
     : basePizzasSold;
-  const pizzaGoal = Number.isFinite(liveStatus.goal) && liveStatus.goal > 0
-    ? liveStatus.goal
+  const pizzaGoal = Number.isFinite(summaryGoal) && summaryGoal > 0
+    ? summaryGoal
     : basePizzaGoal; // default goal to 1000 pizzas
-  const backers = Number.isFinite(liveStatus.backers) && liveStatus.backers >= 0
-    ? Math.max(liveStatus.backers, baseBackers)
+  const backers = Number.isFinite(summaryBackers) && summaryBackers >= 0
+    ? Math.max(summaryBackers, baseBackers)
     : baseBackers;
   const effectiveEndDate = useMemo(() => {
     const fallback = CAMPAIGN_EXTENSION_DEADLINE;
@@ -1262,7 +1234,7 @@ const CrowdfundingPage = () => {
                   label={daysLeft > 0 ? 'days to go' : ''}
                 />
               </div>
-              {statusRefreshError && !Number.isFinite(liveStatus.pizzasSold) && (
+              {statusRefreshError && !Number.isFinite(summaryPizzas) && (
                 <p className="text-xs text-amber-600">
                   Live totals temporarily unavailable; showing published numbers for now.
                 </p>
@@ -1606,19 +1578,24 @@ const CrowdfundingPage = () => {
               </p>
               <form className="space-y-4" onSubmit={handleFeedbackSubmit}>
                 <div className="space-y-2">
-                  <Label htmlFor="pizza-feedback-name">Name (optional)</Label>
-                  <Input
-                    id="pizza-feedback-name"
-                    value={feedbackName}
+                  <Label htmlFor="pizza-feedback-rating">How was your pizza?</Label>
+                  <select
+                    id="pizza-feedback-rating"
+                    value={feedbackRating}
                     onChange={(event) => {
-                      setFeedbackName(event.target.value);
+                      setFeedbackRating(Number(event.target.value));
                       if (feedbackStatus !== 'idle') {
                         setFeedbackStatus('idle');
                         setFeedbackNotice('');
                       }
                     }}
-                    placeholder="Alex Pizza Fan"
-                  />
+                    className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  >
+                    {[5, 4, 3, 2, 1].map((value) => (
+                      <option key={value} value={value}>{`${value} / 5`}</option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-slate-500">5 = legendary pizza party, 1 = needs another try.</p>
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="pizza-feedback-message">What made your pizza special?</Label>
@@ -1664,9 +1641,11 @@ const CrowdfundingPage = () => {
                       key={entry.id}
                       className="rounded-2xl border border-amber-100 bg-amber-50/70 p-4 shadow-sm"
                     >
-                      <p className="text-sm text-amber-900">“{entry.message}”</p>
+                      <p className="text-sm text-amber-900">“{entry.comment}”</p>
                       <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-amber-700">
-                        — {entry.name || 'Anonymous pizza fan'}
+                        {Number.isFinite(entry.rating)
+                          ? `Rating: ${'⭐️'.repeat(Math.max(1, Math.min(5, entry.rating)))} (${entry.rating}/5)`
+                          : 'Rating: shared anonymously'}
                       </p>
                     </li>
                   ))}

--- a/tests/api/square-webhook.test.ts
+++ b/tests/api/square-webhook.test.ts
@@ -1,0 +1,237 @@
+import crypto from 'node:crypto';
+import express from 'express';
+import request from 'supertest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+class FakeDocumentSnapshot {
+  constructor(private readonly _id: string, private readonly _data?: Record<string, unknown>) {}
+
+  get id() {
+    return this._id;
+  }
+
+  get exists() {
+    return this._data !== undefined;
+  }
+
+  data() {
+    return this._data ? clone(this._data) : undefined;
+  }
+}
+
+class FakeDocumentReference {
+  constructor(private readonly store: FakeFirestore, private readonly collectionName: string, private readonly docId: string) {}
+
+  async get() {
+    const data = this.store._getCollection(this.collectionName).get(this.docId);
+    return new FakeDocumentSnapshot(this.docId, data ? clone(data) : undefined);
+  }
+
+  set(data: Record<string, unknown>, options?: { merge?: boolean }) {
+    const collection = this.store._getCollection(this.collectionName);
+    const existing = collection.get(this.docId);
+    if (options?.merge && existing) {
+      collection.set(this.docId, { ...existing, ...clone(data) });
+    } else {
+      collection.set(this.docId, clone(data));
+    }
+  }
+
+  update(data: Record<string, unknown>) {
+    const collection = this.store._getCollection(this.collectionName);
+    const existing = collection.get(this.docId);
+    if (!existing) {
+      throw new Error('not-found');
+    }
+    collection.set(this.docId, { ...existing, ...clone(data) });
+  }
+}
+
+class FakeCollectionReference {
+  constructor(private readonly store: FakeFirestore, private readonly name: string) {}
+
+  doc(id: string) {
+    if (!id) {
+      throw new Error('doc id required');
+    }
+    return new FakeDocumentReference(this.store, this.name, id);
+  }
+}
+
+class FakeTransaction {
+  constructor(private readonly store: FakeFirestore) {}
+
+  async get(ref: FakeDocumentReference) {
+    return ref.get();
+  }
+
+  set(ref: FakeDocumentReference, data: Record<string, unknown>, options?: { merge?: boolean }) {
+    ref.set(data, options);
+  }
+
+  update(ref: FakeDocumentReference, data: Record<string, unknown>) {
+    ref.update(data);
+  }
+}
+
+class FakeFirestore {
+  private readonly collections = new Map<string, Map<string, Record<string, unknown>>>();
+
+  _getCollection(name: string) {
+    if (!this.collections.has(name)) {
+      this.collections.set(name, new Map());
+    }
+    return this.collections.get(name)!;
+  }
+
+  collection(name: string) {
+    return new FakeCollectionReference(this, name);
+  }
+
+  async runTransaction<T>(fn: (tx: FakeTransaction) => Promise<T> | T) {
+    const tx = new FakeTransaction(this);
+    return fn(tx);
+  }
+
+  getDoc(collection: string, id: string) {
+    const data = this._getCollection(collection).get(id);
+    return data ? clone(data) : undefined;
+  }
+}
+
+function clone<T>(value: T): T {
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => clone(item)) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = clone(val);
+    }
+    return result as T;
+  }
+  return value;
+}
+
+vi.mock('../../packages/lib/firebaseAdmin', () => {
+  let currentDb: FakeFirestore | null = null;
+  return {
+    get db() {
+      return currentDb;
+    },
+    __setDb(value: FakeFirestore) {
+      currentDb = value;
+    },
+  };
+});
+
+describe('square webhook handler', () => {
+  let app: express.Express;
+  let fakeDb: FakeFirestore;
+  let handler: (req: express.Request, res: express.Response) => Promise<void>;
+  const notificationUrl = 'https://example.com/api/square/webhook';
+  const secret = 'test-secret';
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    process.env.SQUARE_WEBHOOK_NOTIFICATION_URL = notificationUrl;
+    process.env.SQUARE_WEBHOOK_SIGNATURE_KEY = secret;
+
+    fakeDb = new FakeFirestore();
+    const firebaseAdmin = await import('../../packages/lib/firebaseAdmin');
+    firebaseAdmin.__setDb(fakeDb);
+
+    const module = await import('../../api/square/webhook');
+    handler = module.default;
+
+    app = express();
+    app.post('/api/square/webhook', express.raw({ type: '*/*' }), (req, res) => {
+      handler(req, res);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    delete process.env.SQUARE_WEBHOOK_NOTIFICATION_URL;
+    delete process.env.SQUARE_WEBHOOK_SIGNATURE_KEY;
+  });
+
+  it('persists completed pizza payments once', async () => {
+    const body = {
+      type: 'payment.updated',
+      data: {
+        object: {
+          payment: {
+            id: 'PAYMENT-1',
+            status: 'COMPLETED',
+            customer_id: 'CUSTOMER-1',
+            amount_money: { amount: 4200 },
+            order: {
+              line_items: [
+                { name: 'Community Pizza', quantity: '2' },
+                { name: 'T-Shirt', quantity: '1' },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const payload = JSON.stringify(body);
+    const signature = crypto.createHmac('sha256', secret)
+      .update(notificationUrl + payload)
+      .digest('base64');
+
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    const first = await request(app)
+      .post('/api/square/webhook')
+      .set('x-square-hmacsha256-signature', signature)
+      .set('Content-Type', 'application/json')
+      .send(payload);
+
+    expect(first.status).toBe(200);
+    expect(first.body).toEqual({ ok: true });
+
+    const orderDoc = fakeDb.getDoc('orders', 'PAYMENT-1');
+    expect(orderDoc).toMatchObject({
+      squarePaymentId: 'PAYMENT-1',
+      qty: 2,
+      amount: 4200,
+      status: 'PAID',
+      source: 'square',
+    });
+
+    const backerDoc = fakeDb.getDoc('backers', 'CUSTOMER-1');
+    expect(backerDoc).toMatchObject({
+      ordersCount: 1,
+      amountTotal: 4200,
+    });
+
+    const aggregate = fakeDb.getDoc('aggregates', 'crowdfunding');
+    expect(aggregate?.pizzas).toBe(2);
+    expect(aggregate?.backers).toBe(1);
+    expect(aggregate?.updatedAt).toBeInstanceOf(Date);
+
+    const firstUpdatedAt = aggregate?.updatedAt as Date;
+
+    vi.setSystemTime(new Date('2024-01-02T00:00:00Z'));
+    const second = await request(app)
+      .post('/api/square/webhook')
+      .set('x-square-hmacsha256-signature', signature)
+      .set('Content-Type', 'application/json')
+      .send(payload);
+
+    expect(second.status).toBe(200);
+    expect(second.body).toEqual({ ok: true });
+
+    const aggregateAfter = fakeDb.getDoc('aggregates', 'crowdfunding');
+    expect(aggregateAfter?.pizzas).toBe(2);
+    expect(aggregateAfter?.backers).toBe(1);
+    expect((aggregateAfter?.updatedAt as Date).getTime()).toBe(firstUpdatedAt.getTime());
+  });
+});


### PR DESCRIPTION
## Summary
- add Firebase admin/client helpers and a Square webhook that records completed pizza payments with aggregate updates
- expose Firestore-backed summary and feedback endpoints, tighten rules, and document/backfill the crowdfunding pipeline
- refresh the crowdfunding page to stream live totals via SWR, collect rating-based feedback, and cover webhook idempotency in tests

## Testing
- pnpm exec vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e5d8f9c36483218975de43e861b668