### PR TITLE
Fix crowdfund pizza totals and feedback integration

### DIFF
--- a/api/crowdfund/pizza-feedback.js
+++ b/api/crowdfund/pizza-feedback.js
@@ -12,16 +12,27 @@ const sanitizeMessage = (value) => {
   return str.slice(0, 600);
 };
 
+const sanitizeRating = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  const int = Math.round(num);
+  if (int < 1 || int > 5) return null;
+  return int;
+};
+
 const mapFeedbackDoc = (doc) => {
   if (!doc) return null;
   const data = typeof doc.data === 'function' ? doc.data() : doc;
   if (!data) return null;
-  const message = sanitizeMessage(data.message);
-  if (!message) return null;
+  const comment = sanitizeMessage(data.comment || data.message);
+  if (!comment) return null;
+  const rating = sanitizeRating(data.rating);
   return {
     id: doc.id || data.id || `feedback-${Date.now()}`,
     name: sanitizeName(data.name) || 'Anonymous pizza fan',
-    message,
+    comment,
+    message: comment,
+    rating: rating ?? null,
     createdAt: data.createdAt || null,
   };
 };
@@ -62,15 +73,22 @@ module.exports = async (req, res) => {
     }
 
     const name = sanitizeName(req.body?.name);
-    const message = sanitizeMessage(req.body?.message);
+    const rating = sanitizeRating(req.body?.rating);
+    const comment = sanitizeMessage(req.body?.message ?? req.body?.comment);
 
-    if (!message) {
+    if (!comment) {
       return res.status(400).json({ error: 'Please share a quick note about the pizza.' });
+    }
+
+    if (!Number.isInteger(rating)) {
+      return res.status(400).json({ error: 'Please choose how much you loved the pizza.' });
     }
 
     const entry = {
       name: name || 'Anonymous pizza fan',
-      message,
+      comment,
+      message: comment,
+      rating,
       createdAt: new Date().toISOString(),
       createdAtMs: Date.now(),
       source: 'web',
@@ -78,7 +96,15 @@ module.exports = async (req, res) => {
 
     try {
       const docRef = await db.collection(FEEDBACK_COLLECTION).add(entry);
-      return res.status(200).json({ entry: { ...entry, id: docRef.id || `feedback-${entry.createdAtMs}` } });
+      const responseEntry = {
+        id: docRef.id || `feedback-${entry.createdAtMs}`,
+        name: entry.name,
+        comment: entry.comment,
+        message: entry.comment,
+        rating: entry.rating,
+        createdAt: entry.createdAt,
+      };
+      return res.status(200).json({ entry: responseEntry });
     } catch (error) {
       console.warn('[crowdfund.pizza-feedback] write error', error.message);
       return res.status(500).json({ error: 'Failed to save pizza feedback.' });

--- a/backend/api/routes/__tests__/crowdfunding.test.js
+++ b/backend/api/routes/__tests__/crowdfunding.test.js
@@ -136,12 +136,13 @@ describe('crowdfunding router', () => {
 
     const postRes = await request(app)
       .post('/crowdfund/pizza-feedback')
-      .send({ name: 'Casey', message: 'Loved the basil and char.' });
+      .send({ name: 'Casey', message: 'Loved the basil and char.', rating: 5 });
 
     expect(postRes.status).toBe(200);
     expect(postRes.body.entry).toMatchObject({
       name: 'Casey',
-      message: 'Loved the basil and char.',
+      comment: 'Loved the basil and char.',
+      rating: 5,
     });
     expect(feedbackCollection.add).toHaveBeenCalledTimes(1);
 
@@ -150,7 +151,7 @@ describe('crowdfunding router', () => {
     expect(getRes.body.entries).toHaveLength(1);
     expect(getRes.body.entries[0]).toMatchObject({
       name: 'Casey',
-      message: 'Loved the basil and char.',
+      comment: 'Loved the basil and char.',
     });
     expect(feedbackCollection.orderBy).toHaveBeenCalledWith('createdAtMs', 'desc');
   });

--- a/backend/api/routes/crowdfunding.js
+++ b/backend/api/routes/crowdfunding.js
@@ -18,16 +18,27 @@ function createCrowdfundingRouter({ db, squareClient, logger }) {
     return str.slice(0, 600);
   };
 
+  const sanitizeRating = (value) => {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return null;
+    const int = Math.round(num);
+    if (int < 1 || int > 5) return null;
+    return int;
+  };
+
   const mapFeedbackDoc = (doc) => {
     if (!doc) return null;
     const data = typeof doc.data === 'function' ? doc.data() : doc;
     if (!data) return null;
-    const message = sanitizeMessage(data.message);
-    if (!message) return null;
+    const comment = sanitizeMessage(data.comment || data.message);
+    if (!comment) return null;
+    const rating = sanitizeRating(data.rating);
     return {
       id: doc.id || data.id || `feedback-${Date.now()}`,
       name: sanitizeName(data.name) || 'Anonymous pizza fan',
-      message,
+      comment,
+      message: comment,
+      rating: rating ?? null,
       createdAt: data.createdAt || null,
     };
   };
@@ -191,15 +202,22 @@ function createCrowdfundingRouter({ db, squareClient, logger }) {
       }
 
       const name = sanitizeName(req.body?.name);
-      const message = sanitizeMessage(req.body?.message);
+      const rating = sanitizeRating(req.body?.rating);
+      const comment = sanitizeMessage(req.body?.message ?? req.body?.comment);
 
-      if (!message) {
+      if (!comment) {
         return res.status(400).json({ error: 'Please share a quick note about the pizza.' });
+      }
+
+      if (!Number.isInteger(rating)) {
+        return res.status(400).json({ error: 'Please choose how much you loved the pizza.' });
       }
 
       const entry = {
         name: name || 'Anonymous pizza fan',
-        message,
+        comment,
+        message: comment,
+        rating,
         createdAt: new Date().toISOString(),
         createdAtMs: Date.now(),
         source: 'web',
@@ -214,7 +232,16 @@ function createCrowdfundingRouter({ db, squareClient, logger }) {
         return res.status(500).json({ error: 'Failed to save pizza feedback.' });
       }
 
-      return res.json({ entry: { ...entry, id: docId || `feedback-${entry.createdAtMs}` } });
+      const responseEntry = {
+        id: docId || `feedback-${entry.createdAtMs}`,
+        name: entry.name,
+        comment: entry.comment,
+        message: entry.comment,
+        rating: entry.rating,
+        createdAt: entry.createdAt,
+      };
+
+      return res.json({ entry: responseEntry });
     } catch (error) {
       if (logger) logger.error({ err: error }, 'pizza feedback submit error');
       return res.status(500).json({ error: 'Failed to save pizza feedback.' });

--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -237,24 +237,33 @@ const CrowdfundingPage = () => {
 
     const loadFeedback = async () => {
       try {
-        const res = await fetch('/api/feedback?limit=8', { headers: { Accept: 'application/json' } });
+        const res = await fetch('/api/crowdfund/pizza-feedback?limit=8', { headers: { Accept: 'application/json' } });
         let data = null;
         try {
           data = await res.json();
         } catch (_) {
           data = null;
         }
-        if (!res.ok || (data && data.ok === false)) {
+        if (!res.ok) {
           const message = (data && data.error) || 'Unable to reach the pizza feedback service right now.';
           throw new Error(message);
         }
-        const entries = Array.isArray(data?.items)
-          ? data.items
-              .map((entry) => ({
-                id: entry.id || `feedback-${entry.createdAt || Date.now()}`,
-                rating: Number(entry.rating),
-                comment: typeof entry.comment === 'string' ? entry.comment.trim() : '',
-              }))
+        const entries = Array.isArray(data?.entries)
+          ? data.entries
+              .map((entry) => {
+                const rawRating = Number(entry.rating);
+                const normalizedRating = Number.isFinite(rawRating) && rawRating > 0 ? rawRating : null;
+                const comment = typeof entry.comment === 'string' && entry.comment.trim()
+                  ? entry.comment.trim()
+                  : typeof entry.message === 'string'
+                  ? entry.message.trim()
+                  : '';
+                return {
+                  id: entry.id || `feedback-${entry.createdAt || Date.now()}`,
+                  rating: normalizedRating,
+                  comment,
+                };
+              })
               .filter((entry) => entry.comment)
           : [];
         if (!cancelled) {
@@ -504,10 +513,10 @@ const CrowdfundingPage = () => {
       setFeedbackSubmitting(true);
 
       try {
-        const res = await fetch('/api/feedback', {
+        const res = await fetch('/api/crowdfund/pizza-feedback', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ rating: ratingValue, comment: message }),
+          body: JSON.stringify({ rating: ratingValue, message }),
         });
 
         let data = null;
@@ -517,15 +526,20 @@ const CrowdfundingPage = () => {
           data = null;
         }
 
-        if (!res.ok || (data && data.ok === false)) {
+        if (!res.ok) {
           const messageText = (data && data.error) || 'We had trouble saving your pizza note. Please try again.';
           throw new Error(messageText);
         }
 
+        const payloadEntry = data?.entry;
         const nextEntry = {
-          id: (data && data.id) || `feedback-${Date.now()}`,
-          rating: ratingValue,
-          comment: message,
+          id: (payloadEntry && payloadEntry.id) || `feedback-${Date.now()}`,
+          rating: Number.isFinite(Number(payloadEntry?.rating)) ? Number(payloadEntry.rating) : ratingValue,
+          comment: typeof payloadEntry?.comment === 'string' && payloadEntry.comment.trim()
+            ? payloadEntry.comment.trim()
+            : typeof payloadEntry?.message === 'string' && payloadEntry.message.trim()
+            ? payloadEntry.message.trim()
+            : message,
         };
 
         setFeedbackEntries((prev) => {
@@ -936,14 +950,11 @@ const CrowdfundingPage = () => {
   const hasEvents = upcomingEvents.length > 0;
 
   // --- Pizza-specific values (prefer pizza fields, fallback to legacy money values) ---
-  const basePizzasSold = (() => {
+  const publishedPizzasSold = (() => {
     if (typeof campaignData?.pizzasSold === 'number' && Number.isFinite(campaignData.pizzasSold)) {
       return campaignData.pizzasSold;
     }
-    if (typeof campaignData?.raisedAmount === 'number' && Number.isFinite(campaignData.raisedAmount)) {
-      return campaignData.raisedAmount;
-    }
-    return 0;
+    return null;
   })();
   const basePizzaGoal = (() => {
     if (typeof campaignData?.pizzaGoal === 'number' && Number.isFinite(campaignData.pizzaGoal) && campaignData.pizzaGoal > 0) {
@@ -954,9 +965,18 @@ const CrowdfundingPage = () => {
     }
     return 1000;
   })();
-  const pizzasSold = Number.isFinite(summaryPizzas) && summaryPizzas >= 0
-    ? Math.max(summaryPizzas, basePizzasSold)
-    : basePizzasSold;
+  const fallbackPizzasSold = (() => {
+    if (Number.isFinite(summaryPizzas) && summaryPizzas >= 0) {
+      return summaryPizzas;
+    }
+    if (typeof campaignData?.raisedAmount === 'number' && Number.isFinite(campaignData.raisedAmount)) {
+      return campaignData.raisedAmount;
+    }
+    return 0;
+  })();
+  const pizzasSold = Number.isFinite(publishedPizzasSold)
+    ? publishedPizzasSold
+    : fallbackPizzasSold;
   const pizzaGoal = Number.isFinite(summaryGoal) && summaryGoal > 0
     ? summaryGoal
     : basePizzaGoal; // default goal to 1000 pizzas


### PR DESCRIPTION
## Summary
- update both crowdfund pizza feedback endpoints to store ratings alongside comments in Firestore and normalize responses
- point the crowdfunding page at the pizza feedback API, handling the new payload format and preferring Sanity pizza totals
- refresh the crowdfunding router test to cover the rating requirement

## Testing
- pnpm exec vitest run backend/api/routes/__tests__/crowdfunding.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e67b5a427c83218cd29b4d0ad07d3b