### PR TITLE
Fix crowdfunding summary endpoint regression and document data flow

### DIFF
--- a/api/crowdfunding/summary.ts
+++ b/api/crowdfunding/summary.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { getCrowdfundingSummary } from '../../packages/lib/crowdfundingPipeline';
-import { db as defaultDb } from '../../packages/lib/firebaseAdmin';
 import { db } from '../../packages/lib/firebaseAdmin';
 
 type Req = IncomingMessage & { method?: string };
@@ -37,15 +36,9 @@ export default async function handler(request: Req, response: ServerResponse): P
   }
 
   try {
-    const data = await getCrowdfundingSummary({ db: defaultDb });
-    const snapshot = await db.collection('aggregates').doc('crowdfunding').get();
-    const data = snapshot.exists ? snapshot.data() ?? {} : {};
+    const data = await getCrowdfundingSummary({ db });
     res.setHeader('Cache-Control', 'no-store');
-    res.status(200).json({
-      pizzas: typeof data.pizzas === 'number' ? data.pizzas : 0,
-      backers: typeof data.backers === 'number' ? data.backers : 0,
-      updatedAt: data.updatedAt ?? null,
-    });
+    res.status(200).json(data);
   } catch (error) {
     console.error('[crowdfunding.summary] failed to load aggregate', error);
     res.status(500).json({ ok: false, error: 'internal-error' });

--- a/docs/crowdfunding-data.md
+++ b/docs/crowdfunding-data.md
@@ -1,0 +1,36 @@
+# Crowdfunding data flow
+
+The crowdfunding experience relies on a small set of Firestore collections and
+documents. Use this guide as a checklist when you need to verify that sales are
+being recorded correctly.
+
+## Square webhook (`/api/square/webhook`)
+
+* Writes an order document for each completed Square payment to
+  `orders/{squarePaymentId}` with the quantity, amount, and source metadata.
+  The handler lives in `api/square/webhook.ts` and delegates persistence to the
+  shared pipeline helper. 【F:api/square/webhook.ts†L79-L123】
+* Maintains a backer profile at `backers/{customerId}` so repeat supporters are
+  tracked and counted correctly. 【F:api/square/webhook.ts†L101-L118】
+* Updates the aggregate totals at `aggregates/crowdfunding`, incrementing the
+  pizza count and distinct backer total, and setting a fresh `updatedAt`
+  timestamp. 【F:api/square/webhook.ts†L120-L130】
+
+## Crowdfunding summary API (`/api/crowdfunding/summary`)
+
+* Returns the sanitized contents of `aggregates/crowdfunding`, falling back to
+  zero totals when the document is missing. 【F:api/crowdfunding/summary.ts†L1-L51】
+* Disables caching so the crowdfunding page always renders the most recent
+  numbers. 【F:api/crowdfunding/summary.ts†L39-L45】
+
+## Legacy confirmation flow (`/api/crowdfund/confirm-payment`)
+
+* After the hosted checkout redirects back, the legacy endpoint increments the
+  pizza count stored at `crowdfund/status`, appending the supporter name for the
+  marquee ticker. 【F:backend/api/routes/crowdfunding.js†L88-L141】
+* The same document is surfaced through the serverless version at
+  `/api/crowdfund/status`. 【F:api/crowdfund/status.js†L1-L33】
+
+Between these endpoints and documents you can trace every sale from the Square
+webhook all the way to the numbers displayed on the crowdfunding landing page.
+

--- a/tests/api/crowdfunding-summary.test.ts
+++ b/tests/api/crowdfunding-summary.test.ts
@@ -1,0 +1,75 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { FakeFirestore } from '../support/fakeFirestore';
+
+vi.mock('../../packages/lib/firebaseAdmin', () => {
+  let currentDb: FakeFirestore | null = null;
+  return {
+    get db() {
+      return currentDb;
+    },
+    __setDb(value: FakeFirestore | null) {
+      currentDb = value;
+    },
+  };
+});
+
+describe('crowdfunding summary api', () => {
+  let app: express.Express;
+  let handler: (req: express.Request, res: express.Response) => Promise<void>;
+  let fakeDb: FakeFirestore;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    fakeDb = new FakeFirestore();
+    const firebaseAdmin = await import('../../packages/lib/firebaseAdmin');
+    firebaseAdmin.__setDb(fakeDb);
+
+    const module = await import('../../api/crowdfunding/summary');
+    handler = module.default;
+
+    app = express();
+    app.all('/api/crowdfunding/summary', (req, res) => {
+      handler(req, res);
+    });
+  });
+
+  afterEach(async () => {
+    const firebaseAdmin = await import('../../packages/lib/firebaseAdmin');
+    firebaseAdmin.__setDb(null);
+    vi.resetModules();
+  });
+
+  it('returns the aggregate crowdfunding totals and disables caching', async () => {
+    const updatedAt = new Date('2024-02-01T12:00:00Z');
+    const aggRef = fakeDb.collection('aggregates').doc('crowdfunding');
+    aggRef.set({ pizzas: 42, backers: 17, updatedAt });
+
+    const res = await request(app).get('/api/crowdfunding/summary');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.body).toEqual({
+      pizzas: 42,
+      backers: 17,
+      updatedAt: updatedAt.toISOString(),
+    });
+  });
+
+  it('coerces missing aggregate data to defaults', async () => {
+    const res = await request(app).get('/api/crowdfunding/summary');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ pizzas: 0, backers: 0, updatedAt: null });
+  });
+
+  it('rejects non-GET methods', async () => {
+    const res = await request(app).post('/api/crowdfunding/summary');
+
+    expect(res.status).toBe(405);
+    expect(res.body).toEqual({ ok: false, error: 'method-not-allowed' });
+  });
+});
+

--- a/tests/api/square-webhook.test.ts
+++ b/tests/api/square-webhook.test.ts
@@ -2,119 +2,7 @@ import crypto from 'node:crypto';
 import express from 'express';
 import request from 'supertest';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-
-class FakeDocumentSnapshot {
-  constructor(private readonly _id: string, private readonly _data?: Record<string, unknown>) {}
-
-  get id() {
-    return this._id;
-  }
-
-  get exists() {
-    return this._data !== undefined;
-  }
-
-  data() {
-    return this._data ? clone(this._data) : undefined;
-  }
-}
-
-class FakeDocumentReference {
-  constructor(private readonly store: FakeFirestore, private readonly collectionName: string, private readonly docId: string) {}
-
-  async get() {
-    const data = this.store._getCollection(this.collectionName).get(this.docId);
-    return new FakeDocumentSnapshot(this.docId, data ? clone(data) : undefined);
-  }
-
-  set(data: Record<string, unknown>, options?: { merge?: boolean }) {
-    const collection = this.store._getCollection(this.collectionName);
-    const existing = collection.get(this.docId);
-    if (options?.merge && existing) {
-      collection.set(this.docId, { ...existing, ...clone(data) });
-    } else {
-      collection.set(this.docId, clone(data));
-    }
-  }
-
-  update(data: Record<string, unknown>) {
-    const collection = this.store._getCollection(this.collectionName);
-    const existing = collection.get(this.docId);
-    if (!existing) {
-      throw new Error('not-found');
-    }
-    collection.set(this.docId, { ...existing, ...clone(data) });
-  }
-}
-
-class FakeCollectionReference {
-  constructor(private readonly store: FakeFirestore, private readonly name: string) {}
-
-  doc(id: string) {
-    if (!id) {
-      throw new Error('doc id required');
-    }
-    return new FakeDocumentReference(this.store, this.name, id);
-  }
-}
-
-class FakeTransaction {
-  constructor(private readonly store: FakeFirestore) {}
-
-  async get(ref: FakeDocumentReference) {
-    return ref.get();
-  }
-
-  set(ref: FakeDocumentReference, data: Record<string, unknown>, options?: { merge?: boolean }) {
-    ref.set(data, options);
-  }
-
-  update(ref: FakeDocumentReference, data: Record<string, unknown>) {
-    ref.update(data);
-  }
-}
-
-class FakeFirestore {
-  private readonly collections = new Map<string, Map<string, Record<string, unknown>>>();
-
-  _getCollection(name: string) {
-    if (!this.collections.has(name)) {
-      this.collections.set(name, new Map());
-    }
-    return this.collections.get(name)!;
-  }
-
-  collection(name: string) {
-    return new FakeCollectionReference(this, name);
-  }
-
-  async runTransaction<T>(fn: (tx: FakeTransaction) => Promise<T> | T) {
-    const tx = new FakeTransaction(this);
-    return fn(tx);
-  }
-
-  getDoc(collection: string, id: string) {
-    const data = this._getCollection(collection).get(id);
-    return data ? clone(data) : undefined;
-  }
-}
-
-function clone<T>(value: T): T {
-  if (value instanceof Date) {
-    return new Date(value.getTime()) as unknown as T;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => clone(item)) as unknown as T;
-  }
-  if (value && typeof value === 'object') {
-    const result: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      result[key] = clone(val);
-    }
-    return result as T;
-  }
-  return value;
-}
+import { FakeFirestore } from '../support/fakeFirestore';
 
 vi.mock('../../packages/lib/firebaseAdmin', () => {
   let currentDb: FakeFirestore | null = null;
@@ -122,7 +10,7 @@ vi.mock('../../packages/lib/firebaseAdmin', () => {
     get db() {
       return currentDb;
     },
-    __setDb(value: FakeFirestore) {
+    __setDb(value: FakeFirestore | null) {
       currentDb = value;
     },
   };
@@ -154,8 +42,10 @@ describe('square webhook handler', () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
+    const firebaseAdmin = await import('../../packages/lib/firebaseAdmin');
+    firebaseAdmin.__setDb(null);
     vi.resetModules();
     delete process.env.SQUARE_WEBHOOK_NOTIFICATION_URL;
     delete process.env.SQUARE_WEBHOOK_SIGNATURE_KEY;

--- a/tests/support/fakeFirestore.ts
+++ b/tests/support/fakeFirestore.ts
@@ -1,0 +1,117 @@
+class FakeDocumentSnapshot {
+  constructor(private readonly _id: string, private readonly _data?: Record<string, unknown>) {}
+
+  get id() {
+    return this._id;
+  }
+
+  get exists() {
+    return this._data !== undefined;
+  }
+
+  data() {
+    return this._data ? clone(this._data) : undefined;
+  }
+}
+
+class FakeDocumentReference {
+  constructor(
+    private readonly store: FakeFirestore,
+    private readonly collectionName: string,
+    private readonly docId: string,
+  ) {}
+
+  async get() {
+    const data = this.store._getCollection(this.collectionName).get(this.docId);
+    return new FakeDocumentSnapshot(this.docId, data ? clone(data) : undefined);
+  }
+
+  set(data: Record<string, unknown>, options?: { merge?: boolean }) {
+    const collection = this.store._getCollection(this.collectionName);
+    const existing = collection.get(this.docId);
+    if (options?.merge && existing) {
+      collection.set(this.docId, { ...existing, ...clone(data) });
+    } else {
+      collection.set(this.docId, clone(data));
+    }
+  }
+
+  update(data: Record<string, unknown>) {
+    const collection = this.store._getCollection(this.collectionName);
+    const existing = collection.get(this.docId);
+    if (!existing) {
+      throw new Error('not-found');
+    }
+    collection.set(this.docId, { ...existing, ...clone(data) });
+  }
+}
+
+class FakeCollectionReference {
+  constructor(private readonly store: FakeFirestore, private readonly name: string) {}
+
+  doc(id: string) {
+    if (!id) {
+      throw new Error('doc id required');
+    }
+    return new FakeDocumentReference(this.store, this.name, id);
+  }
+}
+
+class FakeTransaction {
+  constructor(private readonly store: FakeFirestore) {}
+
+  async get(ref: FakeDocumentReference) {
+    return ref.get();
+  }
+
+  set(ref: FakeDocumentReference, data: Record<string, unknown>, options?: { merge?: boolean }) {
+    ref.set(data, options);
+  }
+
+  update(ref: FakeDocumentReference, data: Record<string, unknown>) {
+    ref.update(data);
+  }
+}
+
+export class FakeFirestore {
+  private readonly collections = new Map<string, Map<string, Record<string, unknown>>>();
+
+  _getCollection(name: string) {
+    if (!this.collections.has(name)) {
+      this.collections.set(name, new Map());
+    }
+    return this.collections.get(name)!;
+  }
+
+  collection(name: string) {
+    return new FakeCollectionReference(this, name);
+  }
+
+  async runTransaction<T>(fn: (tx: FakeTransaction) => Promise<T> | T) {
+    const tx = new FakeTransaction(this);
+    return fn(tx);
+  }
+
+  getDoc(collection: string, id: string) {
+    const data = this._getCollection(collection).get(id);
+    return data ? clone(data) : undefined;
+  }
+}
+
+function clone<T>(value: T): T {
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => clone(item)) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = clone(val);
+    }
+    return result as T;
+  }
+  return value;
+}
+


### PR DESCRIPTION
## Summary
- fix `/api/crowdfunding/summary` to reuse the shared summary helper and respond with sanitized totals
- add documentation describing the Firestore destinations for crowdfunding orders, aggregates, and legacy status docs
- extract a reusable FakeFirestore test helper and add vitest coverage around the summary endpoint plus the existing Square webhook flow

## Testing
- pnpm vitest run tests/api/crowdfunding-summary.test.ts
- pnpm vitest run tests/api/square-webhook.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e67e9356bc83219ad87dd82ea1ba4f