### PR TITLE
Fix crowdfunding signup input text color

### DIFF
--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -1518,7 +1518,7 @@ const CrowdfundingPage = () => {
                         value={subscribeEmail}
                         onChange={(event) => setSubscribeEmail(event.target.value)}
                         disabled={subscribeStatus === 'loading'}
-                        className="border-slate-700 bg-slate-800 text-white placeholder:text-slate-400"
+                        className="border-slate-300 bg-white text-slate-900 placeholder:text-slate-500"
                       />
                     </div>
                     {subscribeMessage && (


### PR DESCRIPTION
## Summary
- update the crowdfunding email signup input styles so typed text renders in black on the white background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68ffc70048321b650059c4717880f