### PR TITLE
Migrate menu feedback to Firebase Realtime Database

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,7 @@
+{
+  "emulators": {
+    "database": { "port": 9000 },
+    "firestore": { "port": 8080 },
+    "auth": { "port": 9099 }
+  }
+}

--- a/packages/lib/firebaseAdmin.ts
+++ b/packages/lib/firebaseAdmin.ts
@@ -1,9 +1,11 @@
 import { cert, getApps, initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
+import { getDatabase } from 'firebase-admin/database';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
 const privateKey = process.env.FIREBASE_PRIVATE_KEY;
+const databaseURL = process.env.FIREBASE_DATABASE_URL;
 
 if (!projectId || !clientEmail || !privateKey) {
   throw new Error('Missing Firebase Admin environment variables.');
@@ -18,6 +20,8 @@ const app =
       privateKey: privateKey.replace(/\\n/g, '\n'),
     }),
     projectId,
+    databaseURL,
   });
 
 export const db = getFirestore(app);
+export const realtimeDb = getDatabase(app);

--- a/scripts/migrate-firestore-to-rtdb.js
+++ b/scripts/migrate-firestore-to-rtdb.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const path = require('node:path');
+const fs = require('node:fs');
+const { initializeApp, cert } = require('firebase-admin/app');
+const { getFirestore } = require('firebase-admin/firestore');
+const { getDatabase } = require('firebase-admin/database');
+
+const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH
+  || path.resolve(__dirname, 'serviceAccountKey.json');
+
+if (!fs.existsSync(serviceAccountPath)) {
+  console.error('[migrate] Missing service account JSON.');
+  console.error('[migrate] Provide FIREBASE_SERVICE_ACCOUNT_PATH or place serviceAccountKey.json in scripts/.');
+  process.exit(1);
+}
+
+const serviceAccountRaw = fs.readFileSync(serviceAccountPath, 'utf8');
+const serviceAccount = JSON.parse(serviceAccountRaw);
+
+const databaseURL = process.env.FIREBASE_DATABASE_URL || process.env.RTDB_URL;
+if (!databaseURL) {
+  console.error('[migrate] FIREBASE_DATABASE_URL (or RTDB_URL) must be set to the target Realtime Database URL.');
+  process.exit(1);
+}
+
+initializeApp({
+  credential: cert(serviceAccount),
+  databaseURL,
+});
+
+const firestore = getFirestore();
+const rtdb = getDatabase();
+
+function normalizeTimestamp(value) {
+  if (!value) return { iso: null, ms: null };
+  if (typeof value === 'number') {
+    return { iso: new Date(value).toISOString(), ms: value };
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return { iso: new Date(parsed).toISOString(), ms: parsed };
+    }
+    return { iso: value, ms: null };
+  }
+  if (value.toMillis && typeof value.toMillis === 'function') {
+    try {
+      const ms = value.toMillis();
+      return { iso: new Date(ms).toISOString(), ms };
+    } catch (error) {
+      // ignore
+    }
+  }
+  if (value.toDate && typeof value.toDate === 'function') {
+    try {
+      const date = value.toDate();
+      return { iso: date.toISOString(), ms: date.getTime() };
+    } catch (error) {
+      // ignore
+    }
+  }
+  return { iso: null, ms: null };
+}
+
+async function migrateFeedback() {
+  const snapshot = await firestore.collection('feedback').get();
+  const data = {};
+  snapshot.forEach((doc) => {
+    const value = doc.data() || {};
+    const { iso, ms } = normalizeTimestamp(value.submittedAt || value.createdAt || value.created_at);
+    data[doc.id] = {
+      ...value,
+      submittedAt: iso,
+      submittedAtMs: ms ?? Date.now(),
+    };
+  });
+  await rtdb.ref('feedback').set(data);
+  console.log(`[migrate] Migrated ${snapshot.size} feedback entries.`);
+}
+
+async function migrateMealprepComments() {
+  const root = await firestore.collection('mealprep_comments').get();
+  let total = 0;
+  for (const doc of root.docs) {
+    const commentsSnapshot = await doc.ref.collection('comments').get();
+    const entries = {};
+    commentsSnapshot.forEach((commentDoc) => {
+      const value = commentDoc.data() || {};
+      const { iso, ms } = normalizeTimestamp(value.createdAt || value.created_at);
+      entries[commentDoc.id] = {
+        ...value,
+        createdAt: iso,
+        createdAtMs: ms ?? Date.now(),
+      };
+      total += 1;
+    });
+    await rtdb.ref(`mealprep_comments/${doc.id}/comments`).set(entries);
+  }
+  console.log(`[migrate] Migrated ${total} meal prep comments across ${root.size} menus.`);
+}
+
+async function main() {
+  await migrateFeedback();
+  await migrateMealprepComments();
+  console.log('[migrate] Migration complete.');
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('[migrate] Migration failed:', error);
+  process.exit(1);
+});

--- a/src/components/mealprep/Comments.jsx
+++ b/src/components/mealprep/Comments.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { db } from '../../firebaseConfig';
 import {
-  addDoc,
-  collection,
-  onSnapshot,
-  orderBy,
+  limitToLast,
+  onValue,
+  orderByChild,
+  push,
   query,
+  ref,
   serverTimestamp,
-} from 'firebase/firestore';
+  set,
+} from 'firebase/database';
+import { realtimeDb } from '../../firebaseConfig';
 
 export function Comments({ menuId, user }) {
   const [comments, setComments] = useState([]);
@@ -15,22 +17,30 @@ export function Comments({ menuId, user }) {
   const inputRef = useRef(null);
 
   useEffect(() => {
-  if (!menuId || !db) return;
-    const q = query(collection(db, 'mealprep_comments', menuId, 'comments'), orderBy('createdAt', 'desc'));
-    const unsub = onSnapshot(q, (snap) => {
-      setComments(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+    if (!menuId || !realtimeDb) return undefined;
+    const commentsRef = ref(realtimeDb, `mealprep_comments/${menuId}/comments`);
+    const commentsQuery = query(commentsRef, orderByChild('createdAtMs'), limitToLast(100));
+    const unsubscribe = onValue(commentsQuery, (snap) => {
+      const raw = snap.val() || {};
+      const items = Object.entries(raw).map(([id, value]) => ({ id, ...(value || {}) }));
+      items.sort((a, b) => Number(b.createdAtMs || 0) - Number(a.createdAtMs || 0));
+      setComments(items);
     });
-    return () => unsub();
-  }, [menuId]);
+    return () => unsubscribe();
+  }, [menuId, realtimeDb]);
 
   const submit = async (e) => {
     e.preventDefault();
     const body = text.trim();
     if (!body) return;
-  if (!db) return;
-  await addDoc(collection(db, 'mealprep_comments', menuId, 'comments'), {
+    if (!realtimeDb) return;
+    const commentsRef = ref(realtimeDb, `mealprep_comments/${menuId}/comments`);
+    const newCommentRef = push(commentsRef);
+    const createdAtMs = Date.now();
+    await set(newCommentRef, {
       body,
       createdAt: serverTimestamp(),
+      createdAtMs,
       uid: user?.uid || null,
       name: user?.displayName || 'Anonymous',
     });

--- a/src/components/menu/FeedbackForm.jsx
+++ b/src/components/menu/FeedbackForm.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
-import { db } from '../../firebaseConfig';
+import { ref, push, serverTimestamp, set } from 'firebase/database';
+import { realtimeDb } from '../../firebaseConfig';
 
 const FeedbackForm = () => {
   const [formData, setFormData] = useState({
@@ -25,10 +25,19 @@ const FeedbackForm = () => {
       return;
     }
     setStatus({ type: 'loading', message: 'Submitting...' });
+    if (!realtimeDb) {
+      setStatus({ type: 'error', message: 'Feedback is unavailable right now. Please try again later.' });
+      return;
+    }
+
     try {
-      await addDoc(collection(db, 'feedback'), {
+      const feedbackCollectionRef = ref(realtimeDb, 'feedback');
+      const newFeedbackRef = push(feedbackCollectionRef);
+      const submittedAtMs = Date.now();
+      await set(newFeedbackRef, {
         ...formData,
         submittedAt: serverTimestamp(),
+        submittedAtMs,
       });
       setStatus({ type: 'success', message: 'Thank you! Your feedback has been sent.' });
       setFormData({ name: '', email: '', phone: '', category: 'requests', message: '' }); // Clear form

--- a/src/firebaseConfig.js
+++ b/src/firebaseConfig.js
@@ -13,6 +13,7 @@ const loadAppCheck = () =>
       // app-check is optional; ignore if not available
     });
 import { getFirestore } from 'firebase/firestore';
+import { getDatabase } from 'firebase/database';
 import { getAuth, GoogleAuthProvider, signInWithPopup, signOut } from 'firebase/auth';
 
 // Your web app's Firebase configuration, read from Vite env (fallback to REACT_APP_*)
@@ -24,6 +25,11 @@ const firebaseConfig = {
   storageBucket: env.VITE_STORAGE_BUCKET || env.VITE_FIREBASE_STORAGE_BUCKET || env.REACT_APP_STORAGE_BUCKET,
   messagingSenderId: env.VITE_MESSAGING_SENDER_ID || env.VITE_FIREBASE_MESSAGING_SENDER_ID || env.REACT_APP_MESSAGING_SENDER_ID,
   appId: env.VITE_APP_ID || env.VITE_FIREBASE_APP_ID || env.REACT_APP_APP_ID,
+  databaseURL: env.VITE_DATABASE_URL
+    || env.VITE_FIREBASE_DATABASE_URL
+    || env.REACT_APP_DATABASE_URL
+    || env.REACT_APP_FIREBASE_DATABASE_URL
+    || undefined,
 };
 
 // Initialize Firebase
@@ -56,6 +62,7 @@ try {
 
 // Initialize Cloud Firestore and get a reference to the service
 export const db = app ? getFirestore(app) : null;
+export const realtimeDb = app ? getDatabase(app) : null;
 
 // Auth exports
 export const auth = app ? getAuth(app) : null;


### PR DESCRIPTION
## Summary
- initialize the Firebase Realtime Database alongside existing Firestore setup on both client and admin utilities
- switch the menu feedback form and meal prep comments to read and write via the Realtime Database
- add a migration script and emulator configuration to support moving existing feedback data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6b0f36d248321b2ad1372234b81c5