### PR TITLE
Add Square discount code field to crowdfunding checkout

### DIFF
--- a/api/crowdfund/checkout.js
+++ b/api/crowdfund/checkout.js
@@ -18,7 +18,7 @@ module.exports = async (req, res) => {
     if (!squareClient) return res.status(500).json({ error: 'Square not configured' });
     if (!locationId) return res.status(500).json({ error: 'Square location missing' });
 
-    const { items, funderName, token, email, phone, notes, notify } = req.body || {};
+    const { items, funderName, token, email, phone, notes, notify, discountCode } = req.body || {};
     if (!token) return res.status(400).json({ error: 'Missing payment token' });
     if (!Array.isArray(items) || !items.length) return res.status(400).json({ error: 'No items' });
 
@@ -32,6 +32,8 @@ module.exports = async (req, res) => {
     if (email) metaNoteParts.push(email);
     if (phone) metaNoteParts.push(phone);
     if (notify && notify !== 'none') metaNoteParts.push(`notify:${notify}`);
+    const trimmedDiscount = typeof discountCode === 'string' ? discountCode.trim().slice(0, 60) : '';
+    if (trimmedDiscount) metaNoteParts.push(`discount:${trimmedDiscount}`);
     const noteStr = metaNoteParts.join(' | ').slice(0, 500);
     const paymentBody = {
       sourceId: token,
@@ -58,7 +60,16 @@ module.exports = async (req, res) => {
             } else {
               const data = doc.data() || {};
               const funders = Array.isArray(data.funders) ? data.funders : [];
-              funders.push({ name: funderName, date: new Date().toISOString(), email: email || null, phone: phone || null, notes: notes || null, notify: notify || 'none', pizzas: pizzasInCart });
+              funders.push({
+                name: funderName,
+                date: new Date().toISOString(),
+                email: email || null,
+                phone: phone || null,
+                notes: notes || null,
+                notify: notify || 'none',
+                pizzas: pizzasInCart,
+                discountCode: trimmedDiscount || null,
+              });
               tx.update(docRef, { pizzasSold: (data.pizzasSold || 0) + pizzasInCart, funders });
             }
           });

--- a/api/crowdfund/confirm-payment.js
+++ b/api/crowdfund/confirm-payment.js
@@ -17,7 +17,7 @@ module.exports = async (req, res) => {
     return res.status(503).json({ error: 'Database not configured on this server.' });
   }
 
-  const { items = [], funderName, email, phone, notes, notify } = req.body || {};
+  const { items = [], funderName, email, phone, notes, notify, discountCode } = req.body || {};
   const pizzasInCart = Array.isArray(items)
     ? items
         .filter((item) => item && item.type === 'pizza')
@@ -40,6 +40,8 @@ module.exports = async (req, res) => {
       const pizzasSold = Number(current.pizzasSold) || 0;
       const funders = Array.isArray(current.funders) ? current.funders.slice() : [];
 
+      const trimmedDiscount = typeof discountCode === 'string' ? discountCode.trim().slice(0, 60) : '';
+
       funders.push({
         name: sanitizeName(funderName),
         date: new Date().toISOString(),
@@ -48,6 +50,7 @@ module.exports = async (req, res) => {
         notes: notes || null,
         notify: notify || 'none',
         pizzas: pizzasInCart,
+        discountCode: trimmedDiscount || null,
       });
 
       const payload = {

--- a/api/crowdfund/contribute.js
+++ b/api/crowdfund/contribute.js
@@ -17,7 +17,7 @@ module.exports = async (req, res) => {
     return res.status(500).json({ error: 'Square location missing' });
   }
 
-  const { items } = req.body || {};
+  const { items, discountCode } = req.body || {};
   if (!Array.isArray(items) || items.length === 0) {
     return res.status(400).json({ error: 'Cart is empty.' });
   }
@@ -42,12 +42,21 @@ module.exports = async (req, res) => {
     askForShippingAddress: true,
   };
 
+  const trimmedDiscount = typeof discountCode === 'string' ? discountCode.trim().slice(0, 60) : '';
+
   try {
     const response = await squareClient.checkoutApi.createPaymentLink({
       idempotencyKey: uuidv4(),
       order: {
         locationId,
         lineItems,
+        ...(trimmedDiscount
+          ? {
+              metadata: {
+                discountCode: trimmedDiscount,
+              },
+            }
+          : {}),
       },
       checkoutOptions,
     });

--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -348,6 +348,7 @@ const CrowdfundingPage = () => {
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
   const [notes, setNotes] = useState('');
+  const [squareDiscountCode, setSquareDiscountCode] = useState('');
   const notify = 'none';
   const [showForm, setShowForm] = useState(false);
   const [pizzaQty, setPizzaQty] = useState(1);
@@ -787,7 +788,7 @@ const CrowdfundingPage = () => {
   const [cardReady, setCardReady] = useState(false);
   const [cardError, setCardError] = useState('');
   const { notify: notifyToast } = useToast();
-  const rememberPendingContribution = useCallback((cartItems, name) => {
+  const rememberPendingContribution = useCallback((cartItems, name, discountCode) => {
     if (!Array.isArray(cartItems) || cartItems.length === 0) return;
     try {
       localStorage.setItem('cf_items', JSON.stringify(cartItems));
@@ -795,6 +796,12 @@ const CrowdfundingPage = () => {
         localStorage.setItem('cf_name', name);
       } else {
         localStorage.removeItem('cf_name');
+      }
+      const trimmedDiscount = typeof discountCode === 'string' ? discountCode.trim() : '';
+      if (trimmedDiscount) {
+        localStorage.setItem('cf_discount', trimmedDiscount);
+      } else {
+        localStorage.removeItem('cf_discount');
       }
     } catch (err) {
       console.warn('[square] [crowdfunding] failed to persist pending contribution', err);
@@ -804,6 +811,7 @@ const CrowdfundingPage = () => {
     try {
       localStorage.removeItem('cf_items');
       localStorage.removeItem('cf_name');
+      localStorage.removeItem('cf_discount');
     } catch (err) {
       console.warn('[square] [crowdfunding] failed to clear pending contribution', err);
     }
@@ -919,10 +927,11 @@ const CrowdfundingPage = () => {
           const raw = localStorage.getItem('cf_items');
           const items = raw ? JSON.parse(raw) : [];
           const name = localStorage.getItem('cf_name') || undefined;
+          const discountCode = localStorage.getItem('cf_discount') || undefined;
           if (Array.isArray(items) && items.length > 0) {
             const res = await fetch('/api/crowdfund/confirm-payment', {
               method: 'POST', headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ items, funderName: name })
+              body: JSON.stringify({ items, funderName: name, discountCode })
             });
             if (res.ok) {
               setConfirmMsg('Thanks! Your contribution has been recorded.');
@@ -984,7 +993,11 @@ const CrowdfundingPage = () => {
         const linkRes = await fetch('/api/crowdfund/contribute', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ items: linkItems, funderName: funderName || undefined }),
+          body: JSON.stringify({
+            items: linkItems,
+            funderName: funderName || undefined,
+            discountCode: squareDiscountCode.trim() || undefined,
+          }),
         });
         if (linkRes.ok) {
           const linkData = await linkRes.json().catch(() => ({}));
@@ -995,7 +1008,11 @@ const CrowdfundingPage = () => {
               pizzaCount: item.pizzaCount,
               quantity: item.quantity,
             }));
-            rememberPendingContribution(itemsForStorage, funderName?.trim() || '');
+            rememberPendingContribution(
+              itemsForStorage,
+              funderName?.trim() || '',
+              squareDiscountCode.trim()
+            );
             notifyToast('Redirecting to secure checkout…', { type: 'success' });
             window.location.assign(linkData.url);
             return;
@@ -1028,6 +1045,7 @@ const CrowdfundingPage = () => {
         notify,
         token,
         pizzaQty,
+        discountCode: squareDiscountCode.trim() || undefined,
       };
       const res = await fetch('/api/crowdfund/checkout', {
         method: 'POST',
@@ -1049,6 +1067,7 @@ const CrowdfundingPage = () => {
         throw new Error(msg);
       }
       setConfirmMsg('Thanks! Your contribution has been processed.');
+      setSquareDiscountCode('');
     } catch (e) {
       setPayError(e?.message || 'Payment failed');
       notifyToast(e?.message || 'Payment failed', { type: 'error' });
@@ -1577,6 +1596,19 @@ const CrowdfundingPage = () => {
                   {referralState.status === 'error' && (
                     <p className="text-sm text-red-600">Unable to validate that code right now.</p>
                   )}
+                  <div className="space-y-2">
+                    <Label htmlFor="cf-square-discount">Square discount code (optional)</Label>
+                    <Input
+                      id="cf-square-discount"
+                      placeholder="Discount code"
+                      autoComplete="off"
+                      value={squareDiscountCode}
+                      onChange={(e) => setSquareDiscountCode(e.target.value)}
+                    />
+                    <p className="text-xs text-slate-500">
+                      We'll include this code with your secure Square checkout.
+                    </p>
+                  </div>
                   {activeTier && (
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
                       <div className="space-y-2">


### PR DESCRIPTION
## Summary
- add a Square discount code input to the crowdfunding checkout form and include it in pending contribution persistence
- forward the discount code to Square payment link and embedded checkout flows, storing it with crowdfund records

## Testing
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6b35eb32083219b451d8236f702d1