### PR TITLE
Fix crowdfunding discount code build regression

### DIFF
--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -1173,7 +1173,6 @@ const CrowdfundingPage = () => {
             items: linkItems,
             funderName: funderName || undefined,
             discountCode: trimmedDiscount || undefined,
-            discountCode: squareDiscountCode.trim() || undefined,
           }),
         });
         if (linkRes.ok) {
@@ -1193,7 +1192,6 @@ const CrowdfundingPage = () => {
               itemsForStorage,
               funderName?.trim() || '',
               trimmedDiscount || ''
-              squareDiscountCode.trim()
             );
             notifyToast('Redirecting to secure checkout…', { type: 'success' });
             window.location.assign(linkData.url);
@@ -1222,7 +1220,6 @@ const CrowdfundingPage = () => {
         token,
         pizzaQty,
         discountCode: trimmedDiscount || undefined,
-        discountCode: squareDiscountCode.trim() || undefined,
       };
       const res = await fetch('/api/crowdfund/checkout', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- remove the duplicate discountCode fields from crowdfunding checkout requests that broke production builds
- keep pending crowdfunding contributions storing the trimmed discount code with the expected function signature

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7180491f483219565c650a3dc861e