### PR TITLE
Add frozen pizza option to crowdfunding reward preferences

### DIFF
--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -377,6 +377,7 @@ const REWARD_PREFERENCE_OPTIONS = [
   { value: 'public pizza party', label: 'Public pizza party' },
   { value: 'deliver to my home', label: 'Deliver to my home' },
   { value: 'make live at my home', label: 'Make live at my home' },
+  { value: 'frozen pizza', label: 'Frozen pizza' },
   { value: "i'm open or im not sure", label: 'I’m open or I’m not sure' },
 ];
 


### PR DESCRIPTION
## Summary
- add a Frozen pizza entry to the crowdfunding reward preference options so supporters can select it in the pledge form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7212c2bf88321a447616bea6ff615