### PR TITLE
Connect crowdfunding tracker to Firebase realtime data

### DIFF
--- a/src/lib/firebaseCrowdfunding.js
+++ b/src/lib/firebaseCrowdfunding.js
@@ -1,0 +1,207 @@
+import { getApps, initializeApp } from 'firebase/app';
+import {
+  collection,
+  doc,
+  getFirestore,
+  limit as limitQuery,
+  onSnapshot,
+  orderBy,
+  query,
+} from 'firebase/firestore';
+import devConsole from './devConsole.js';
+
+let cachedApp = null;
+let initAttempted = false;
+
+const getEnv = () => {
+  if (typeof import.meta !== 'undefined' && import.meta.env) {
+    return import.meta.env;
+  }
+  return {};
+};
+
+const readEnvValue = (suffix) => {
+  const env = getEnv();
+  return (
+    env[`VITE_FIREBASE_${suffix}`] ||
+    env[`NEXT_PUBLIC_FIREBASE_${suffix}`] ||
+    env[`PUBLIC_FIREBASE_${suffix}`] ||
+    null
+  );
+};
+
+const buildFirebaseConfig = () => {
+  const apiKey = readEnvValue('API_KEY');
+  const authDomain = readEnvValue('AUTH_DOMAIN');
+  const projectId = readEnvValue('PROJECT_ID');
+  const appId = readEnvValue('APP_ID');
+  const messagingSenderId = readEnvValue('MESSAGING_SENDER_ID');
+  const databaseURL =
+    readEnvValue('DATABASE_URL') || readEnvValue('DATABASEURL') || undefined;
+
+  if (!apiKey || !authDomain || !projectId || !appId || !messagingSenderId) {
+    return null;
+  }
+
+  const config = {
+    apiKey,
+    authDomain,
+    projectId,
+    appId,
+    messagingSenderId,
+  };
+
+  if (databaseURL) {
+    config.databaseURL = databaseURL;
+  }
+
+  return config;
+};
+
+export const getFirebaseAppInstance = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  if (cachedApp) {
+    return cachedApp;
+  }
+  if (initAttempted) {
+    return null;
+  }
+  initAttempted = true;
+
+  const config = buildFirebaseConfig();
+  if (!config) {
+    devConsole.warn?.('[firebase] missing client configuration for crowdfunding');
+    return null;
+  }
+
+  try {
+    cachedApp = getApps()[0] ?? initializeApp(config);
+    return cachedApp;
+  } catch (error) {
+    cachedApp = null;
+    devConsole.warn?.('[firebase] failed to initialize client app', error);
+    return null;
+  }
+};
+
+const normalizeTimestamp = (value) => {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  if (typeof value === 'object' && typeof value.toDate === 'function') {
+    try {
+      return value.toDate();
+    } catch (error) {
+      return null;
+    }
+  }
+  return null;
+};
+
+const sanitizeFeedbackText = (value) =>
+  String(value || '')
+    .replace(/\r/g, '')
+    .trim();
+
+const sanitizeFeedbackRating = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  const rounded = Math.round(num);
+  if (rounded < 1 || rounded > 5) return null;
+  return rounded;
+};
+
+export const watchCrowdfundingTotals = ({ onUpdate, onError } = {}) => {
+  const app = getFirebaseAppInstance();
+  if (!app) {
+    return null;
+  }
+
+  try {
+    const firestore = getFirestore(app);
+    const totalsRef = doc(firestore, 'aggregates', 'crowdfunding');
+
+    return onSnapshot(
+      totalsRef,
+      (snapshot) => {
+        const raw = snapshot.exists() ? snapshot.data() || {} : {};
+        const pizzas = Number(raw.pizzas);
+        const backers = Number(raw.backers);
+        const goal = Number(raw.goal);
+        const updatedAt = normalizeTimestamp(raw.updatedAt);
+        if (onUpdate) {
+          onUpdate({
+            pizzas: Number.isFinite(pizzas) ? pizzas : null,
+            backers: Number.isFinite(backers) ? backers : null,
+            goal: Number.isFinite(goal) && goal > 0 ? goal : null,
+            updatedAt,
+          });
+        }
+      },
+      (error) => {
+        devConsole.warn?.('[firebase] crowdfunding totals listener error', error);
+        if (onError) onError(error);
+      }
+    );
+  } catch (error) {
+    devConsole.warn?.('[firebase] crowdfunding totals listener failed', error);
+    if (onError) onError(error);
+    return null;
+  }
+};
+
+export const watchPizzaFeedback = ({ limit = 8, onUpdate, onError } = {}) => {
+  const app = getFirebaseAppInstance();
+  if (!app) {
+    return null;
+  }
+
+  const normalizedLimit = Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), 30) : 8;
+
+  try {
+    const firestore = getFirestore(app);
+    const feedbackRef = collection(firestore, 'crowdfund_feedback');
+    const feedbackQuery = query(
+      feedbackRef,
+      orderBy('createdAtMs', 'desc'),
+      limitQuery(normalizedLimit)
+    );
+
+    return onSnapshot(
+      feedbackQuery,
+      (snapshot) => {
+        const entries = snapshot.docs
+          .map((docSnap) => {
+            const data = docSnap.data() || {};
+            const comment = sanitizeFeedbackText(data.comment || data.message);
+            if (!comment) {
+              return null;
+            }
+            return {
+              id: docSnap.id || `feedback-${data.createdAtMs || Date.now()}`,
+              comment,
+              rating: sanitizeFeedbackRating(data.rating),
+              createdAt: normalizeTimestamp(data.createdAt) ?? null,
+            };
+          })
+          .filter(Boolean);
+        if (onUpdate) {
+          onUpdate(entries);
+        }
+      },
+      (error) => {
+        devConsole.warn?.('[firebase] pizza feedback listener error', error);
+        if (onError) onError(error);
+      }
+    );
+  } catch (error) {
+    devConsole.warn?.('[firebase] pizza feedback listener failed', error);
+    if (onError) onError(error);
+    return null;
+  }
+};

--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -23,6 +23,7 @@ import { createPortableTextComponents } from '../utils/portableTextComponents';
 import { cn } from '../lib/utils';
 import { useToast } from '../components/common/ToastProvider';
 import devConsole from '../lib/devConsole.js';
+import { watchCrowdfundingTotals, watchPizzaFeedback } from '../lib/firebaseCrowdfunding';
 
 const REALTIME_DATABASE_URL = 'https://local-effort-default-rtdb.firebaseio.com/';
 const FIREBASE_DATABASE_PATTERN = /firebase database/gi;
@@ -427,10 +428,13 @@ const CrowdfundingPage = () => {
   const [feedbackSubmitting, setFeedbackSubmitting] = useState(false);
   const [feedbackLoading, setFeedbackLoading] = useState(false);
   const [feedbackFetchError, setFeedbackFetchError] = useState('');
+  const [realtimeTotals, setRealtimeTotals] = useState(null);
+  const [feedbackRealtimeStatus, setFeedbackRealtimeStatus] = useState('idle'); // idle | connecting | ready | error | disabled
   // Gallery state (lazy-loaded when tab activated)
   const [galleryImages, setGalleryImages] = useState([]);
   const [galleryLoading, setGalleryLoading] = useState(false);
   const [galleryError, setGalleryError] = useState('');
+  const feedbackFallbackStatusRef = useRef(null);
   const galleryLoadedRef = useRef(false);
   const [eventModal, setEventModal] = useState(null);
 
@@ -445,7 +449,60 @@ const CrowdfundingPage = () => {
   const summaryPizzas = Number(summaryData?.pizzas);
   const summaryBackers = Number(summaryData?.backers);
   const summaryGoal = Number(summaryData?.goal);
-  const statusRefreshError = Boolean(summaryError);
+  const summaryTotalsAvailable =
+    !summaryError && Number.isFinite(summaryPizzas) && summaryPizzas >= 0;
+  const summaryBackersAvailable =
+    !summaryError && Number.isFinite(summaryBackers) && summaryBackers >= 0;
+  const livePizzas = Number.isFinite(Number(realtimeTotals?.pizzas))
+    ? Number(realtimeTotals.pizzas)
+    : null;
+  const liveBackers = Number.isFinite(Number(realtimeTotals?.backers))
+    ? Number(realtimeTotals.backers)
+    : null;
+  const liveGoal = Number.isFinite(Number(realtimeTotals?.goal))
+    ? Number(realtimeTotals.goal)
+    : null;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    let unsubscribe = null;
+    let active = true;
+
+    try {
+      const maybeUnsubscribe = watchCrowdfundingTotals({
+        onUpdate: (data) => {
+          if (!active) return;
+          setRealtimeTotals(data);
+        },
+        onError: (error) => {
+          if (!active) return;
+          if (error) {
+            devConsole.warn('[crowdfunding] realtime totals listener error', error);
+          }
+        },
+      });
+
+      if (typeof maybeUnsubscribe === 'function') {
+        unsubscribe = maybeUnsubscribe;
+      } else if (active) {
+        devConsole.warn('[crowdfunding] realtime totals disabled - missing client configuration?');
+      }
+    } catch (error) {
+      if (active) {
+        devConsole.warn('[crowdfunding] failed to start realtime totals listener', error);
+      }
+    }
+
+    return () => {
+      active = false;
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (activeTab === 'gallery' && !galleryLoadedRef.current) {
@@ -498,6 +555,75 @@ const CrowdfundingPage = () => {
   }, [activeTab]);
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    let unsubscribe = null;
+    let active = true;
+
+    setFeedbackRealtimeStatus('connecting');
+    setFeedbackLoading(true);
+
+    try {
+      const maybeUnsubscribe = watchPizzaFeedback({
+        limit: 8,
+        onUpdate: (entries) => {
+          if (!active) return;
+          setFeedbackEntries(entries);
+          setFeedbackLoading(false);
+          setFeedbackFetchError('');
+          setFeedbackRealtimeStatus('ready');
+        },
+        onError: (error) => {
+          if (!active) return;
+          setFeedbackLoading(false);
+          setFeedbackRealtimeStatus('error');
+          if (error) {
+            devConsole.warn('[crowdfunding] realtime pizza feedback listener error', error);
+          }
+        },
+      });
+
+      if (typeof maybeUnsubscribe === 'function') {
+        unsubscribe = maybeUnsubscribe;
+      } else if (active) {
+        setFeedbackRealtimeStatus('disabled');
+        setFeedbackLoading(false);
+        devConsole.warn('[crowdfunding] realtime pizza feedback disabled - missing client configuration?');
+      }
+    } catch (error) {
+      if (active) {
+        setFeedbackRealtimeStatus('error');
+        setFeedbackLoading(false);
+        devConsole.warn('[crowdfunding] failed to start realtime pizza feedback listener', error);
+      }
+    }
+
+    return () => {
+      active = false;
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (feedbackRealtimeStatus === 'ready') {
+      feedbackFallbackStatusRef.current = null;
+      return undefined;
+    }
+
+    if (!['disabled', 'error'].includes(feedbackRealtimeStatus)) {
+      return undefined;
+    }
+
+    if (feedbackFallbackStatusRef.current === feedbackRealtimeStatus) {
+      return undefined;
+    }
+
+    feedbackFallbackStatusRef.current = feedbackRealtimeStatus;
+
     let cancelled = false;
     setFeedbackLoading(true);
     setFeedbackFetchError('');
@@ -559,7 +685,7 @@ const CrowdfundingPage = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [feedbackRealtimeStatus]);
   // Simple client-side validators
   const emailValid = useMemo(() => !email || /.+@.+\..+/.test(email), [email]);
   const phoneDigits = useMemo(() => phone.replace(/\D/g, ''), [phone]);
@@ -1442,10 +1568,7 @@ const CrowdfundingPage = () => {
     }
     return 1000;
   })();
-  const fallbackPizzasSold = (() => {
-    if (Number.isFinite(summaryPizzas) && summaryPizzas >= 0) {
-      return summaryPizzas;
-    }
+  const fallbackPizzasBase = (() => {
     if (
       typeof campaignData?.raisedAmount === 'number' &&
       Number.isFinite(campaignData.raisedAmount)
@@ -1454,14 +1577,35 @@ const CrowdfundingPage = () => {
     }
     return 0;
   })();
-  const pizzasSold = Number.isFinite(publishedPizzasSold)
+
+  let pizzasSold = Number.isFinite(publishedPizzasSold)
     ? publishedPizzasSold
-    : fallbackPizzasSold;
-  const pizzaGoal = Number.isFinite(summaryGoal) && summaryGoal > 0 ? summaryGoal : basePizzaGoal; // default goal to 1000 pizzas
-  const backers =
-    Number.isFinite(summaryBackers) && summaryBackers >= 0
-      ? Math.max(summaryBackers, baseBackers)
-      : baseBackers;
+    : fallbackPizzasBase;
+  if (summaryTotalsAvailable) {
+    pizzasSold = summaryPizzas;
+  }
+  if (Number.isFinite(livePizzas)) {
+    pizzasSold = livePizzas;
+  }
+
+  const usingPublishedFallback =
+    !Number.isFinite(livePizzas) && !summaryTotalsAvailable && Number.isFinite(publishedPizzasSold);
+
+  const showLiveTotalsFallbackNotice = usingPublishedFallback;
+
+  const pizzaGoal = Number.isFinite(liveGoal) && liveGoal > 0
+    ? liveGoal
+    : Number.isFinite(summaryGoal) && summaryGoal > 0
+      ? summaryGoal
+      : basePizzaGoal; // default goal to 1000 pizzas
+
+  let backers = baseBackers;
+  if (summaryBackersAvailable) {
+    backers = Math.max(summaryBackers, baseBackers);
+  }
+  if (Number.isFinite(liveBackers)) {
+    backers = Math.max(liveBackers, baseBackers);
+  }
   const effectiveEndDate = useMemo(() => {
     const fallback = CAMPAIGN_EXTENSION_DEADLINE;
     if (!endDate) return fallback;
@@ -1747,7 +1891,7 @@ const CrowdfundingPage = () => {
                   label={daysLeft > 0 ? 'days to go' : ''}
                 />
               </div>
-              {statusRefreshError && !Number.isFinite(summaryPizzas) && (
+              {showLiveTotalsFallbackNotice && (
                 <p className="text-xs text-amber-600">
                   Live totals temporarily unavailable; showing published numbers for now.
                 </p>


### PR DESCRIPTION
## Summary
- add a reusable Firebase client helper for crowdfunding totals and feedback listeners
- subscribe the crowdfunding page to realtime totals and feedback with Sanity-based fallbacks when live data is unavailable
- surface a fallback notice when the tracker must rely on published Sanity values

## Testing
- pnpm test tests/api/crowdfunding-summary.test.ts *(hangs in this environment; vite test never finished)*

------
https://chatgpt.com/codex/tasks/task_e_68e7231fdfd4832185cb712f95275bbb