### PR TITLE
Fix crowdfunding discount validation and fallback summary

### DIFF
--- a/api/crowdfunding/summary.ts
+++ b/api/crowdfunding/summary.ts
@@ -2,6 +2,9 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { getCrowdfundingSummary } from '../../packages/lib/crowdfundingPipeline';
 import { db } from '../../packages/lib/firebaseAdmin';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { loadPublishedCrowdfundingSummary } = require('../../packages/lib/crowdfundingFallbacks');
+
 type Req = IncomingMessage & { method?: string };
 type Res = ServerResponse & {
   status: (code: number) => Res;
@@ -41,6 +44,16 @@ export default async function handler(request: Req, response: ServerResponse): P
     res.status(200).json(data);
   } catch (error) {
     console.error('[crowdfunding.summary] failed to load aggregate', error);
+    try {
+      const fallback = await loadPublishedCrowdfundingSummary();
+      if (fallback) {
+        res.setHeader('Cache-Control', 'no-store');
+        res.status(200).json(fallback);
+        return;
+      }
+    } catch (fallbackError) {
+      console.warn('[crowdfunding.summary] fallback load failed', fallbackError);
+    }
     res.status(500).json({ ok: false, error: 'internal-error' });
   }
 }

--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -38,6 +38,9 @@ const {
   createFeedback,
   listFeedback,
 } = require('../../packages/lib/crowdfundingPipeline');
+const {
+  loadPublishedCrowdfundingSummary,
+} = require('../../packages/lib/crowdfundingFallbacks');
 
 // Fallback: if critical vars are missing, also try loading project root .env
 if (!process.env.SQUARE_ACCESS_TOKEN || !process.env.BREVO_API_KEY) {
@@ -360,14 +363,23 @@ app.get('/api/crowdfunding/summary', async (req, res) => {
   try {
     const data = await getCrowdfundingSummary({ db });
     res.set('Cache-Control', 'no-store');
-    res.json({
+    return res.json({
       pizzas: typeof data.pizzas === 'number' ? data.pizzas : Number(data.pizzas) || 0,
       backers: typeof data.backers === 'number' ? data.backers : Number(data.backers) || 0,
       updatedAt: data.updatedAt ?? null,
     });
   } catch (err) {
     if (logger?.error) logger.error({ err }, 'crowdfunding summary error');
-    res.status(500).json({ ok: false, error: 'internal-error' });
+    try {
+      const fallback = await loadPublishedCrowdfundingSummary({ sanityClient: getSanityClient });
+      if (fallback) {
+        res.set('Cache-Control', 'no-store');
+        return res.json(fallback);
+      }
+    } catch (fallbackErr) {
+      if (logger?.warn) logger.warn({ err: fallbackErr }, 'crowdfunding summary fallback error');
+    }
+    return res.status(500).json({ ok: false, error: 'internal-error' });
   }
 });
 app.get('/api/feedback', async (req, res) => {

--- a/backend/api/routes/__tests__/crowdfunding.test.js
+++ b/backend/api/routes/__tests__/crowdfunding.test.js
@@ -39,6 +39,22 @@ describe('crowdfunding router', () => {
     expect(res.body).toEqual({ error: 'Cart is empty.' });
   });
 
+  it('validates discount codes defensively', async () => {
+    const warn = vi.fn();
+    const app = createApp({ logger: { warn, error: vi.fn() } });
+
+    const missing = await request(app).post('/crowdfund/discount-code').send({});
+    expect(missing.status).toBe(400);
+    expect(missing.body.error).toBe('missing-code');
+
+    const invalid = await request(app)
+      .post('/crowdfund/discount-code')
+      .send({ code: 'NOTREAL' });
+    expect(invalid.status).toBe(200);
+    expect(invalid.body).toEqual({ valid: false });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it('creates a payment link via Square', async () => {
     const createPaymentLink = vi.fn().mockResolvedValue({
       result: { paymentLink: { url: 'https://square.test/link' } },

--- a/backend/api/routes/crowdfunding.js
+++ b/backend/api/routes/crowdfunding.js
@@ -1,5 +1,8 @@
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
+const {
+  resolveCrowdfundDiscount,
+} = require('../../../api/crowdfund/_lib/discountCodes');
 
 function createCrowdfundingRouter({ db, squareClient, logger }) {
   const router = express.Router();
@@ -113,6 +116,27 @@ function createCrowdfundingRouter({ db, squareClient, logger }) {
     } catch (error) {
       if (logger) logger.error({ err: error }, 'square create payment link error');
       return res.status(500).json({ error: 'Failed to create payment link.' });
+    }
+  });
+
+  router.post('/discount-code', async (req, res) => {
+    try {
+      const { code } = req.body || {};
+      if (!code || typeof code !== 'string' || !code.trim()) {
+        return res.status(400).json({ error: 'missing-code' });
+      }
+
+      const discount = resolveCrowdfundDiscount(code);
+      if (!discount) {
+        return res.json({ valid: false });
+      }
+
+      return res.json({ valid: true, discount });
+    } catch (error) {
+      if (logger?.warn) {
+        logger.warn({ err: error }, 'crowdfund discount validation failed');
+      }
+      return res.status(500).json({ error: 'unable-to-validate-discount' });
     }
   });
 

--- a/packages/lib/crowdfundingFallbacks.js
+++ b/packages/lib/crowdfundingFallbacks.js
@@ -1,0 +1,109 @@
+const DEFAULT_CAMPAIGN_SLUG = process.env.CROWDFUND_SANITY_SLUG
+  || 'local-pizza-by-local-effort-let-s-make-1000-pizzas';
+
+let cachedSanityClient = null;
+
+const numberOrNull = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  return num;
+};
+
+function getDefaultSanityClient() {
+  if (cachedSanityClient) {
+    return cachedSanityClient;
+  }
+
+  const projectId = process.env.SANITY_PROJECT_ID;
+  if (!projectId) {
+    return null;
+  }
+
+  try {
+    // eslint-disable-next-line global-require
+    const { createClient } = require('@sanity/client');
+    const dataset = process.env.SANITY_DATASET || 'localeffort';
+    cachedSanityClient = createClient({
+      projectId,
+      dataset,
+      useCdn: false,
+      token: process.env.SANITY_API_TOKEN || undefined,
+      apiVersion: '2024-01-01',
+    });
+    return cachedSanityClient;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('[crowdfunding.fallback] failed to create Sanity client', error && error.message);
+    return null;
+  }
+}
+
+function extractPublishedCrowdfundingSummary(campaign) {
+  if (!campaign || typeof campaign !== 'object') {
+    return null;
+  }
+
+  const pizzasCandidates = [
+    numberOrNull(campaign.pizzasSold),
+    numberOrNull(campaign.piesSold),
+    numberOrNull(campaign.raisedAmount),
+  ].filter((value) => value !== null && value >= 0);
+
+  const pizzas = pizzasCandidates.length > 0 ? pizzasCandidates[0] : null;
+  const backers = numberOrNull(campaign.backers);
+  const goalCandidates = [
+    numberOrNull(campaign.pizzaGoal),
+    numberOrNull(campaign.goal),
+  ].filter((value) => value !== null && value > 0);
+  const goal = goalCandidates.length > 0 ? goalCandidates[0] : null;
+  const updatedAt = campaign.updatedAt
+    || campaign._updatedAt
+    || campaign._createdAt
+    || null;
+
+  if (pizzas === null && backers === null && goal === null) {
+    return null;
+  }
+
+  return {
+    pizzas: Number.isFinite(pizzas) ? pizzas : 0,
+    backers: Number.isFinite(backers) ? backers : 0,
+    goal: Number.isFinite(goal) ? goal : null,
+    updatedAt,
+    source: 'published',
+  };
+}
+
+async function loadPublishedCrowdfundingSummary(options = {}) {
+  const sanityClient = (() => {
+    if (options.sanityClient) {
+      if (typeof options.sanityClient === 'function') {
+        return options.sanityClient();
+      }
+      return options.sanityClient;
+    }
+    return getDefaultSanityClient();
+  })();
+
+  if (!sanityClient || typeof sanityClient.fetch !== 'function') {
+    return null;
+  }
+
+  const slug = options.slug || DEFAULT_CAMPAIGN_SLUG;
+  const query = '*[_type == "crowdfundingCampaign" && slug.current == $slug][0]{\n    pizzasSold,\n    piesSold,\n    pizzaGoal,\n    goal,\n    raisedAmount,\n    backers,\n    updatedAt,\n    _updatedAt\n  }';
+
+  try {
+    const data = await sanityClient.fetch(query, { slug });
+    return extractPublishedCrowdfundingSummary(data);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('[crowdfunding.fallback] failed to fetch published summary', error && error.message);
+    return null;
+  }
+}
+
+module.exports = {
+  DEFAULT_CAMPAIGN_SLUG,
+  extractPublishedCrowdfundingSummary,
+  loadPublishedCrowdfundingSummary,
+};


### PR DESCRIPTION
## Summary
- add an express handler for crowdfund discount codes and cover negative paths in tests
- share a Sanity-backed fallback for the crowdfunding summary endpoint when Firestore is unavailable

## Testing
- pnpm vitest run backend/api/routes/__tests__/crowdfunding.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e730bea3f88321b70925f808befb53