### PR TITLE
Fix receipt scope issues in crowdfund flows

### DIFF
--- a/api/crowdfund/confirm-payment.js
+++ b/api/crowdfund/confirm-payment.js
@@ -79,14 +79,14 @@ module.exports = async (req, res) => {
 
   try {
     const docRef = db.collection('crowdfund').doc('status');
+    const trimmedDiscount = typeof discountCode === 'string' ? discountCode.trim().slice(0, 60) : '';
+
     await db.runTransaction(async (transaction) => {
       const doc = await transaction.get(docRef);
       const current = doc.exists ? doc.data() || {} : {};
       const goal = typeof current.goal === 'number' ? current.goal : 1000;
       const pizzasSold = Number(current.pizzasSold) || 0;
       const funders = Array.isArray(current.funders) ? current.funders.slice() : [];
-
-      const trimmedDiscount = typeof discountCode === 'string' ? discountCode.trim().slice(0, 60) : '';
 
       funders.push({
         name: sanitizedFunderName,

--- a/src/pages/CrowdfundingPage.jsx
+++ b/src/pages/CrowdfundingPage.jsx
@@ -1842,7 +1842,7 @@ const CrowdfundingPage = () => {
         funderName: funderName?.trim() || '',
         discountCode: trimmedDiscount || '',
         discountLabel:
-          (data?.discount && data.discount.label) || (discountDetails && discountDetails.label) || '',
+          (data?.discount && data.discount.label) || (discountFromState && discountFromState.label) || '',
       });
       setLastContributionTotal(Math.max(0, Math.round(totalAfterLocalDiscount)));
       setSquareDiscountCode('');


### PR DESCRIPTION
## Summary
- ensure confirm-payment reuses the trimmed discount code when sending receipts after the transaction
- prevent the checkout success handler from referencing an undefined discount descriptor

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec36cae3ec8321a24fbcb7291d990d