### PR TITLE
Handle missing database for zero-dollar crowdfund confirmations

### DIFF
--- a/backend/api/routes/__tests__/crowdfunding.test.js
+++ b/backend/api/routes/__tests__/crowdfunding.test.js
@@ -156,6 +156,21 @@ describe('crowdfunding router', () => {
     expect(stored?.funders?.[0]?.name).toBe('Tester');
   });
 
+  it('gracefully skips persistence when confirm-payment runs without a database', async () => {
+    const warn = vi.fn();
+    const app = createApp({ logger: { warn, error: vi.fn() } });
+
+    const res = await request(app)
+      .post('/crowdfund/confirm-payment')
+      .send({ items: [{ type: 'pizza', pizzaCount: 1 }], funderName: 'Fallback Fan' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, fallback: true });
+    expect(warn).toHaveBeenCalledWith(
+      'crowdfund confirm-payment requested but database unavailable; skipping persistence'
+    );
+  });
+
   it('stores and retrieves pizza feedback entries', async () => {
     const stored = [];
     const feedbackCollection = {

--- a/backend/api/routes/crowdfunding.js
+++ b/backend/api/routes/crowdfunding.js
@@ -163,7 +163,16 @@ function createCrowdfundingRouter({ db, squareClient, logger }) {
       }
 
       if (!db) {
-        return res.status(500).json({ error: 'Database not configured on this server.' });
+        if (logger?.warn) {
+          logger.warn(
+            'crowdfund confirm-payment requested but database unavailable; skipping persistence'
+          );
+        }
+        return res.json({
+          success: true,
+          fallback: true,
+          message: 'Contribution recorded without database update.',
+        });
       }
 
       const docRef = db.collection('crowdfund').doc('status');


### PR DESCRIPTION
## Summary
- allow crowdfund confirm-payment to succeed even when Firestore is unavailable
- log a warning and flag fallback responses for complimentary contributions
- add coverage ensuring confirm-payment degrades gracefully without a database

## Testing
- pnpm vitest run backend/api/routes/__tests__/crowdfunding.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ec3d6a75c88321926e7cf50d1ee997