### PR TITLE
Prefer service account project ID over ambient env vars

### DIFF
--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -113,19 +113,22 @@ try {
     }
   }
 
-  const resolvedProjectId =
+  const serviceAccountProjectId =
+    serviceAccount?.project_id || serviceAccount?.projectId || null;
+
+  const ambientProjectId =
     process.env.FIREBASE_PROJECT_ID ||
     process.env.GOOGLE_CLOUD_PROJECT ||
     process.env.GCLOUD_PROJECT ||
     process.env.GCP_PROJECT ||
-    serviceAccount?.project_id ||
-    serviceAccount?.projectId ||
     null;
+
+  const resolvedProjectId = serviceAccountProjectId || ambientProjectId;
 
   if (serviceAccount) {
     const firebaseOptions = { credential: admin.credential.cert(serviceAccount) };
-    if (resolvedProjectId) {
-      firebaseOptions.projectId = resolvedProjectId;
+    if (serviceAccountProjectId || ambientProjectId) {
+      firebaseOptions.projectId = serviceAccountProjectId || ambientProjectId;
     }
 
     if (!admin.apps.length) {


### PR DESCRIPTION
## Summary
- prefer the service account's embedded project ID when configuring Firestore
- only fall back to ambient environment variables when the service account omits a project identifier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec5f5be06483219218221a18f2d786