### PR TITLE
Improve firebase admin initialization fallback

### DIFF
--- a/api/_lib/firebaseAdmin.js
+++ b/api/_lib/firebaseAdmin.js
@@ -11,6 +11,68 @@ try {
 
 let cached = null;
 
+const candidateProjectEnvKeys = [
+  'FIREBASE_PROJECT_ID',
+  'GOOGLE_CLOUD_PROJECT',
+  'GCLOUD_PROJECT',
+  'GCP_PROJECT',
+  'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
+  'NEXT_PUBLIC_PROJECT_ID',
+  'VITE_FIREBASE_PROJECT_ID',
+  'VITE_PROJECT_ID',
+  'REACT_APP_FIREBASE_PROJECT_ID',
+  'REACT_APP_PROJECT_ID',
+];
+
+const clientConfigEnvKeys = [
+  'FIREBASE_CLIENT_CONFIG_JSON',
+  'FIREBASE_CLIENT_CONFIG',
+  'FIREBASE_PUBLIC_CONFIG_JSON',
+  'FIREBASE_PUBLIC_CONFIG',
+  'NEXT_PUBLIC_FIREBASE_CONFIG',
+  'VITE_FIREBASE_CONFIG',
+  'REACT_APP_FIREBASE_CONFIG',
+  'FIREBASE_WEB_CONFIG',
+  'FIREBASE_OPTIONS',
+  'FIREBASE_CONFIG',
+];
+
+const safeParseJson = (value) => {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return null;
+  }
+};
+
+const safeDecodeBase64Json = (value) => {
+  if (!value) return null;
+  const raw = String(value).trim();
+  if (!raw) return null;
+
+  if (raw.startsWith('{') || raw.startsWith('\u007b')) {
+    return safeParseJson(raw);
+  }
+
+  const unquoted = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+    ? raw.slice(1, -1)
+    : raw;
+
+  const candidates = [unquoted, unquoted.replace(/\s+/g, ''), unquoted.replace(/-/g, '+').replace(/_/g, '/')];
+  for (const cand of candidates) {
+    try {
+      const decoded = Buffer.from(cand, 'base64').toString('utf8');
+      const parsed = safeParseJson(decoded);
+      if (parsed) return parsed;
+    } catch (error) {
+      // try next candidate
+    }
+  }
+
+  return null;
+};
+
 const readJsonFromEnv = (value, label) => {
   if (!value) return null;
   try {
@@ -88,9 +150,70 @@ const normalizePrivateKey = (value) => {
   }
 };
 
+const resolveProjectIdFromObject = (candidate) => {
+  if (!candidate || typeof candidate !== 'object') return null;
+  const projectId = candidate.project_id || candidate.projectId || candidate.projectID || candidate.project;
+  if (typeof projectId === 'string' && projectId.trim()) {
+    return projectId.trim();
+  }
+  return null;
+};
+
+const resolveProjectIdFromEnv = () => {
+  for (const key of candidateProjectEnvKeys) {
+    const value = process.env[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  const serviceAccountJson = safeParseJson(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+  const serviceAccountBase64 = safeDecodeBase64Json(process.env.FIREBASE_SERVICE_ACCOUNT_BASE64);
+  const serviceAccountFromPath = safeParseJson(
+    (() => {
+      try {
+        if (!process.env.FIREBASE_SERVICE_ACCOUNT_PATH) return null;
+        if (!fs.existsSync(process.env.FIREBASE_SERVICE_ACCOUNT_PATH)) return null;
+        return fs.readFileSync(process.env.FIREBASE_SERVICE_ACCOUNT_PATH, 'utf8');
+      } catch (error) {
+        return null;
+      }
+    })(),
+  );
+
+  const serviceAccountProjectId =
+    resolveProjectIdFromObject(serviceAccountJson) ||
+    resolveProjectIdFromObject(serviceAccountBase64) ||
+    resolveProjectIdFromObject(serviceAccountFromPath);
+  if (serviceAccountProjectId) return serviceAccountProjectId;
+
+  for (const key of clientConfigEnvKeys) {
+    const parsed = safeParseJson(process.env[key]);
+    const projectId = resolveProjectIdFromObject(parsed);
+    if (projectId) return projectId;
+  }
+
+  return null;
+};
+
+const applyProjectIdEnv = (projectId) => {
+  if (!projectId || typeof projectId !== 'string' || !projectId.trim()) return;
+  const value = projectId.trim();
+  try {
+    if (!process.env.FIREBASE_PROJECT_ID) process.env.FIREBASE_PROJECT_ID = value;
+    if (!process.env.GOOGLE_CLOUD_PROJECT) process.env.GOOGLE_CLOUD_PROJECT = value;
+    if (!process.env.GCLOUD_PROJECT) process.env.GCLOUD_PROJECT = value;
+    if (!process.env.GCP_PROJECT) process.env.GCP_PROJECT = value;
+  } catch (error) {
+    // Ignore env assignment failures (read-only env)
+  }
+};
+
 function coerceServiceAccount(candidate) {
   if (!candidate || typeof candidate !== 'object') return null;
-  const projectId = candidate.project_id || candidate.projectId || process.env.FIREBASE_PROJECT_ID;
+  const projectId =
+    resolveProjectIdFromObject(candidate) ||
+    resolveProjectIdFromEnv();
   const clientEmail = candidate.client_email || candidate.clientEmail || process.env.FIREBASE_CLIENT_EMAIL;
   const privateKey = normalizePrivateKey(candidate.private_key || candidate.privateKey || process.env.FIREBASE_PRIVATE_KEY);
 
@@ -116,7 +239,7 @@ function loadServiceAccount() {
   }
 
   const fallback = coerceServiceAccount({
-    projectId: process.env.FIREBASE_PROJECT_ID,
+    projectId: resolveProjectIdFromEnv(),
     clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
     privateKey: process.env.FIREBASE_PRIVATE_KEY,
   });
@@ -160,10 +283,12 @@ function getFirebaseAdmin() {
   try {
     if (!admin.apps.length) {
       const serviceAccount = loadServiceAccount();
+      const resolvedProjectId = serviceAccount?.projectId || resolveProjectIdFromEnv();
+      const databaseURL = process.env.FIREBASE_DATABASE_URL || undefined;
       if (serviceAccount) {
         // Ensure process.env has fallback values so firebase-admin can detect project id in different runtimes
         try {
-          if (!process.env.FIREBASE_PROJECT_ID && serviceAccount.projectId) process.env.FIREBASE_PROJECT_ID = serviceAccount.projectId;
+          applyProjectIdEnv(serviceAccount.projectId);
           if (!process.env.FIREBASE_CLIENT_EMAIL && serviceAccount.clientEmail) process.env.FIREBASE_CLIENT_EMAIL = serviceAccount.clientEmail;
         } catch (e) {
           // ignore env set failures
@@ -175,15 +300,46 @@ function getFirebaseAdmin() {
             privateKey: serviceAccount.privateKey,
           }),
           projectId: serviceAccount.projectId,
-          databaseURL: process.env.FIREBASE_DATABASE_URL || undefined,
+          databaseURL,
         });
         console.warn('[firebase-admin] initialized with explicit service account credentials');
       } else {
-        admin.initializeApp();
-        console.warn('[firebase-admin] initialized with default application credentials');
+        const baseOptions = {};
+        if (resolvedProjectId) baseOptions.projectId = resolvedProjectId;
+        if (databaseURL) baseOptions.databaseURL = databaseURL;
+
+        let initialized = false;
+        if (typeof admin.credential?.applicationDefault === 'function') {
+          try {
+            admin.initializeApp({
+              ...baseOptions,
+              credential: admin.credential.applicationDefault(),
+            });
+            initialized = true;
+            console.warn('[firebase-admin] initialized with application default credentials');
+          } catch (error) {
+            console.warn('[firebase-admin] applicationDefault credentials unavailable', error.message);
+          }
+        }
+
+        if (!initialized) {
+          admin.initializeApp(baseOptions);
+          if (resolvedProjectId) {
+            console.warn('[firebase-admin] initialized with project ID only (no explicit credentials)');
+          } else {
+            console.warn('[firebase-admin] initialized without explicit project ID; Firestore will be disabled if unavailable');
+          }
+        }
       }
     }
     firestore = typeof admin.firestore === 'function' ? admin.firestore() : null;
+    const projectId = (admin?.apps?.[0] && admin.apps[0].options && admin.apps[0].options.projectId) || resolveProjectIdFromEnv();
+    if (projectId) {
+      applyProjectIdEnv(projectId);
+    } else {
+      console.warn('[firebase-admin] project ID could not be resolved; disabling Firestore access to avoid runtime errors.');
+      firestore = null;
+    }
   } catch (error) {
     console.warn('[firebase-admin] failed to initialize app', error.message);
     if (process.env.FIREBASE_PRIVATE_KEY || process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {

--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -21,7 +21,6 @@ try {
 }
 const express = require('express');
 const cors = require('cors');
-const admin = require('firebase-admin');
 const { getSanityClient } = require('./sanityClient');
 const fs = require('fs');
 const path = require('path');
@@ -70,113 +69,23 @@ try {
 } catch (err) {
   console.warn('Square SDK not available or failed to load:', err && err.message);
 }
-const { v4: uuidv4 } = require('uuid'); // Import UUID for idempotency
-
-// --- INITIALIZE FIREBASE ---
-let db;
-// Support either raw JSON in FIREBASE_SERVICE_ACCOUNT_JSON or a path to a JSON file in FIREBASE_SERVICE_ACCOUNT_PATH
-try {
-  let serviceAccount = null;
-  if (process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
-    serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
-  } else if (process.env.FIREBASE_SERVICE_ACCOUNT_BASE64) {
-    try {
-      const decoded = Buffer.from(process.env.FIREBASE_SERVICE_ACCOUNT_BASE64, 'base64').toString('utf8');
-      serviceAccount = JSON.parse(decoded);
-    } catch (err) {
-      console.warn('FIREBASE_SERVICE_ACCOUNT_BASE64 present but failed to decode/parse:', err?.message);
-    }
-  } else if (process.env.FIREBASE_SERVICE_ACCOUNT_PATH) {
-    const path = process.env.FIREBASE_SERVICE_ACCOUNT_PATH;
-    if (fs.existsSync(path)) {
-      const raw = fs.readFileSync(path, 'utf8');
-      serviceAccount = JSON.parse(raw);
-    } else {
-      console.warn(`FIREBASE_SERVICE_ACCOUNT_PATH set but file does not exist: ${path}`);
-    }
-  } else if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-    const path = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-    if (fs.existsSync(path)) {
-      try {
-        const raw = fs.readFileSync(path, 'utf8');
-        serviceAccount = JSON.parse(raw);
-      } catch (err) {
-        console.warn(
-          'GOOGLE_APPLICATION_CREDENTIALS present but failed to read/parse:',
-          err?.message
-        );
-      }
-    } else {
-      console.warn(
-        `GOOGLE_APPLICATION_CREDENTIALS set but file does not exist: ${path}`
-      );
-    }
+const { getFirebaseAdmin } = require('../../api/_lib/firebaseAdmin');
+const firebaseAdminResources = (() => {
+  try {
+    return getFirebaseAdmin();
+  } catch (error) {
+    console.warn('[backend] failed to load firebase admin helper', error?.message || error);
+    return { admin: null, firestore: null };
   }
+})();
 
-  const resolvedProjectId =
-    process.env.FIREBASE_PROJECT_ID ||
-    process.env.GOOGLE_CLOUD_PROJECT ||
-    process.env.GCLOUD_PROJECT ||
-    process.env.GCP_PROJECT ||
-    serviceAccount?.project_id ||
-    serviceAccount?.projectId ||
-    null;
-
-  if (serviceAccount) {
-    const firebaseOptions = { credential: admin.credential.cert(serviceAccount) };
-    if (resolvedProjectId) {
-      firebaseOptions.projectId = resolvedProjectId;
-    }
-
-    if (!admin.apps.length) {
-      admin.initializeApp(firebaseOptions);
-    }
-
-    db = admin.firestore();
-  } else {
-    if (!resolvedProjectId) {
-      console.warn(
-        'Firebase service account not provided and no project ID configured — Firestore will be unavailable in this process.'
-      );
-    } else {
-      try {
-        if (!admin.apps.length) {
-          admin.initializeApp({ projectId: resolvedProjectId });
-        }
-        db = admin.firestore();
-      } catch (err) {
-        console.warn('Failed to initialize Firebase admin with project ID only:', err.message);
-      }
-    }
-  }
-
-  if (db) {
-    const finalProjectId =
-      admin.app().options?.projectId ||
-      resolvedProjectId ||
-      process.env.GOOGLE_CLOUD_PROJECT ||
-      process.env.GCLOUD_PROJECT ||
-      null;
-
-    if (finalProjectId) {
-      if (!process.env.GOOGLE_CLOUD_PROJECT) process.env.GOOGLE_CLOUD_PROJECT = finalProjectId;
-      if (!process.env.GCLOUD_PROJECT) process.env.GCLOUD_PROJECT = finalProjectId;
-      if (!process.env.FIREBASE_PROJECT_ID) process.env.FIREBASE_PROJECT_ID = finalProjectId;
-    } else {
-      console.warn(
-        'Firestore initialized but no project ID could be resolved — disabling database access to avoid runtime errors.'
-      );
-      db = null;
-    }
-  }
-
-  if (!db) {
-    console.warn('Firestore will be unavailable in this process.');
-  }
-} catch (err) {
-  console.error('Failed to initialize Firebase admin:', err.message);
+const admin = firebaseAdminResources.admin;
+const db = firebaseAdminResources.firestore;
+if (!db) {
   console.warn('Firestore will be unavailable in this process.');
 }
+
+const { v4: uuidv4 } = require('uuid'); // Import UUID for idempotency
 
 // --- Auth middleware for admin-only endpoints (Gallant tools) ---
 const GALLANT_ALLOWED = new Set([

--- a/packages/lib/firebaseAdmin.ts
+++ b/packages/lib/firebaseAdmin.ts
@@ -14,6 +14,68 @@ type FirebaseResources = {
 
 let cached: FirebaseResources | null = null;
 
+const candidateProjectEnvKeys = [
+  'FIREBASE_PROJECT_ID',
+  'GOOGLE_CLOUD_PROJECT',
+  'GCLOUD_PROJECT',
+  'GCP_PROJECT',
+  'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
+  'NEXT_PUBLIC_PROJECT_ID',
+  'VITE_FIREBASE_PROJECT_ID',
+  'VITE_PROJECT_ID',
+  'REACT_APP_FIREBASE_PROJECT_ID',
+  'REACT_APP_PROJECT_ID',
+] as const;
+
+const clientConfigEnvKeys = [
+  'FIREBASE_CLIENT_CONFIG_JSON',
+  'FIREBASE_CLIENT_CONFIG',
+  'FIREBASE_PUBLIC_CONFIG_JSON',
+  'FIREBASE_PUBLIC_CONFIG',
+  'NEXT_PUBLIC_FIREBASE_CONFIG',
+  'VITE_FIREBASE_CONFIG',
+  'REACT_APP_FIREBASE_CONFIG',
+  'FIREBASE_WEB_CONFIG',
+  'FIREBASE_OPTIONS',
+  'FIREBASE_CONFIG',
+] as const;
+
+function safeParseJson(value: string | undefined | null): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return null;
+  }
+}
+
+function safeDecodeBase64Json(value: string | undefined | null): Record<string, unknown> | null {
+  if (!value) return null;
+  const raw = String(value).trim();
+  if (!raw) return null;
+
+  if (raw.startsWith('{') || raw.startsWith('\u007b')) {
+    return safeParseJson(raw);
+  }
+
+  const unquoted = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+    ? raw.slice(1, -1)
+    : raw;
+
+  const candidates = [unquoted, unquoted.replace(/\s+/g, ''), unquoted.replace(/-/g, '+').replace(/_/g, '/')];
+  for (const cand of candidates) {
+    try {
+      const decoded = Buffer.from(cand, 'base64').toString('utf8');
+      const parsed = safeParseJson(decoded);
+      if (parsed) return parsed;
+    } catch (error) {
+      // ignore and try next candidate
+    }
+  }
+
+  return null;
+}
+
 function normalizePrivateKey(value: unknown): string | null {
   if (!value) return null;
   const raw = String(value);
@@ -55,11 +117,70 @@ function readJsonFile(filePath: string | undefined): Record<string, unknown> | n
   }
 }
 
-function coerceServiceAccount(candidate: Record<string, unknown> | null): ServiceAccount | null {
+function resolveProjectIdFromObject(candidate: Record<string, unknown> | null): string | null {
   if (!candidate) return null;
-  const projectId = (candidate.project_id ?? candidate.projectId ?? process.env.FIREBASE_PROJECT_ID) as
+  const projectId = (candidate.project_id ?? candidate.projectId ?? candidate.projectID ?? candidate.project) as
     | string
     | undefined;
+  if (projectId && projectId.trim()) {
+    return projectId.trim();
+  }
+  return null;
+}
+
+function resolveProjectIdFromEnv(): string | null {
+  for (const key of candidateProjectEnvKeys) {
+    const value = process.env[key];
+    if (value && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  const serviceAccountJson = safeParseJson(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+  const serviceAccountBase64 = safeDecodeBase64Json(process.env.FIREBASE_SERVICE_ACCOUNT_BASE64);
+  const serviceAccountFromPath = safeParseJson(
+    (() => {
+      try {
+        if (!process.env.FIREBASE_SERVICE_ACCOUNT_PATH) return null;
+        if (!fs.existsSync(process.env.FIREBASE_SERVICE_ACCOUNT_PATH)) return null;
+        return fs.readFileSync(process.env.FIREBASE_SERVICE_ACCOUNT_PATH, 'utf8');
+      } catch (error) {
+        return null;
+      }
+    })(),
+  );
+
+  const serviceAccountProjectId =
+    resolveProjectIdFromObject(serviceAccountJson) ||
+    resolveProjectIdFromObject(serviceAccountBase64) ||
+    resolveProjectIdFromObject(serviceAccountFromPath);
+  if (serviceAccountProjectId) return serviceAccountProjectId;
+
+  for (const key of clientConfigEnvKeys) {
+    const parsed = safeParseJson(process.env[key]);
+    const projectId = resolveProjectIdFromObject(parsed);
+    if (projectId) return projectId;
+  }
+
+  return null;
+}
+
+function applyProjectIdEnv(projectId: string | null | undefined) {
+  if (!projectId || !projectId.trim()) return;
+  const value = projectId.trim();
+  try {
+    if (!process.env.FIREBASE_PROJECT_ID) process.env.FIREBASE_PROJECT_ID = value;
+    if (!process.env.GOOGLE_CLOUD_PROJECT) process.env.GOOGLE_CLOUD_PROJECT = value;
+    if (!process.env.GCLOUD_PROJECT) process.env.GCLOUD_PROJECT = value;
+    if (!process.env.GCP_PROJECT) process.env.GCP_PROJECT = value;
+  } catch (error) {
+    // ignore failures (read-only env)
+  }
+}
+
+function coerceServiceAccount(candidate: Record<string, unknown> | null): ServiceAccount | null {
+  if (!candidate) return null;
+  const projectId = resolveProjectIdFromObject(candidate) ?? resolveProjectIdFromEnv() ?? undefined;
   const clientEmail = (candidate.client_email ?? candidate.clientEmail ?? process.env.FIREBASE_CLIENT_EMAIL) as
     | string
     | undefined;
@@ -105,7 +226,7 @@ function resolveServiceAccount(): ServiceAccount | null {
   if (fromPath) return fromPath;
 
   return coerceServiceAccount({
-    projectId: process.env.FIREBASE_PROJECT_ID,
+    projectId: resolveProjectIdFromEnv() ?? undefined,
     clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
     privateKey: process.env.FIREBASE_PRIVATE_KEY,
   });
@@ -115,34 +236,61 @@ function initializeFirebase(): FirebaseResources {
   try {
     if (!getApps().length) {
       const serviceAccount = resolveServiceAccount();
+      const resolvedProjectId = serviceAccount?.projectId ?? resolveProjectIdFromEnv() ?? undefined;
       const databaseURL = process.env.FIREBASE_DATABASE_URL;
 
       if (serviceAccount) {
+        applyProjectIdEnv(serviceAccount.projectId);
         initializeApp({
           credential: cert(serviceAccount),
           projectId: serviceAccount.projectId,
           databaseURL,
         });
       } else {
+        const baseOptions: Parameters<typeof initializeApp>[0] = {};
+        if (resolvedProjectId) baseOptions.projectId = resolvedProjectId;
+        if (databaseURL) baseOptions.databaseURL = databaseURL;
+
+        let initialized = false;
         try {
+          const credential = applicationDefault();
           initializeApp({
-            credential: applicationDefault(),
-            projectId: process.env.FIREBASE_PROJECT_ID,
-            databaseURL,
+            ...baseOptions,
+            credential,
           });
+          initialized = true;
+          console.warn('[firebase-admin] initialized with application default credentials');
         } catch (error) {
           console.warn('[firebase-admin] applicationDefault credentials unavailable', (error as Error).message);
-          initializeApp({
-            projectId: process.env.FIREBASE_PROJECT_ID,
-            databaseURL,
-          });
+        }
+
+        if (!initialized) {
+          initializeApp(baseOptions);
+          if (resolvedProjectId) {
+            console.warn('[firebase-admin] initialized with project ID only (no explicit credentials)');
+          } else {
+            console.warn('[firebase-admin] initialized without explicit project ID; Firestore will be disabled if unavailable');
+          }
         }
       }
     }
 
     const app = getApps()[0] ?? null;
-    const db = app ? getFirestore(app) : null;
-    const realtimeDb = app ? getDatabase(app) : null;
+    let db: Firestore | null = null;
+    let realtimeDb: Database | null = null;
+    if (app) {
+      db = getFirestore(app);
+      realtimeDb = getDatabase(app);
+      const projectId =
+        (app.options?.projectId as string | undefined) ?? resolveProjectIdFromEnv() ?? undefined;
+      if (projectId) {
+        applyProjectIdEnv(projectId);
+      } else {
+        console.warn('[firebase-admin] project ID could not be resolved; disabling Firestore access to avoid runtime errors.');
+        db = null;
+        realtimeDb = null;
+      }
+    }
 
     return { app, db, realtimeDb };
   } catch (error) {


### PR DESCRIPTION
## Summary
- expand firebase admin environment detection to accept project ids from additional deployment variables and disable Firestore when none can be resolved
- reuse the shared firebase admin helper in the backend API so serverless runtimes pick up the unified fallback logic
- update the TypeScript firebase admin helper with the same resiliency improvements to keep API routes consistent

## Testing
- pnpm vitest run tests/api/crowdfunding-summary.test.ts *(fails: goal defaults in FakeFirestore expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68ec6314b9008321b322b7fe7ae5f191