### PR TITLE
Preserve Firestore access when project ID env detection fails

### DIFF
--- a/api/_lib/firebaseAdmin.js
+++ b/api/_lib/firebaseAdmin.js
@@ -333,12 +333,24 @@ function getFirebaseAdmin() {
       }
     }
     firestore = typeof admin.firestore === 'function' ? admin.firestore() : null;
-    const projectId = (admin?.apps?.[0] && admin.apps[0].options && admin.apps[0].options.projectId) || resolveProjectIdFromEnv();
+
+    const appOptions = admin?.apps?.[0]?.options || {};
+    let projectId = appOptions.projectId || resolveProjectIdFromEnv();
+    if (!projectId) {
+      const credentialProjectId = appOptions.credential && appOptions.credential.projectId;
+      if (typeof credentialProjectId === 'string' && credentialProjectId) {
+        projectId = credentialProjectId;
+      }
+    }
+
     if (projectId) {
       applyProjectIdEnv(projectId);
+    } else if (!firestore) {
+      console.warn('[firebase-admin] project ID could not be resolved and Firestore is unavailable.');
     } else {
-      console.warn('[firebase-admin] project ID could not be resolved; disabling Firestore access to avoid runtime errors.');
-      firestore = null;
+      console.warn(
+        '[firebase-admin] project ID could not be resolved from env or credentials; continuing with Firestore using default credential discovery.'
+      );
     }
   } catch (error) {
     console.warn('[firebase-admin] failed to initialize app', error.message);

--- a/packages/lib/firebaseAdmin.ts
+++ b/packages/lib/firebaseAdmin.ts
@@ -281,14 +281,25 @@ function initializeFirebase(): FirebaseResources {
     if (app) {
       db = getFirestore(app);
       realtimeDb = getDatabase(app);
-      const projectId =
-        (app.options?.projectId as string | undefined) ?? resolveProjectIdFromEnv() ?? undefined;
+
+      const appOptions = app.options ?? {};
+      let projectId =
+        (appOptions.projectId as string | undefined) ?? resolveProjectIdFromEnv() ?? undefined;
+      if (!projectId) {
+        const credentialProjectId = (appOptions.credential as { projectId?: unknown } | undefined)?.projectId;
+        if (typeof credentialProjectId === 'string' && credentialProjectId) {
+          projectId = credentialProjectId;
+        }
+      }
+
       if (projectId) {
         applyProjectIdEnv(projectId);
+      } else if (!db || !realtimeDb) {
+        console.warn('[firebase-admin] project ID could not be resolved and database clients are unavailable.');
       } else {
-        console.warn('[firebase-admin] project ID could not be resolved; disabling Firestore access to avoid runtime errors.');
-        db = null;
-        realtimeDb = null;
+        console.warn(
+          '[firebase-admin] project ID could not be resolved from env or credentials; continuing with Firestore using default credential discovery.'
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- keep Firestore clients available when default credentials supply the project ID implicitly
- look for a project ID on the initialized credential before falling back to environment resolution
- only disable database clients when initialization fails to produce them entirely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed027aa24c8321be60d19483a6d363